### PR TITLE
Exit emscripten runtime when user program ends

### DIFF
--- a/express.js
+++ b/express.js
@@ -33,18 +33,26 @@ app.post('/compile', (req, res) => {
     });
   }
 
+  const augmentedCode = req.body.code + `
+  #include <emscripten.h>
+ 
+  void simMainWrapper()
+  {
+    main();
+    emscripten_force_exit(0);
+  }`;
 
-
+  
   const id = uuid();
   const path = `/tmp/${id}.c`;
-  fs.writeFile(path, req.body.code, err => {
+  fs.writeFile(path, augmentedCode, err => {
     if (err) {
       return res.status(500).json({
         error: "Failed to write ${}"
       })
     }
 
-    exec(`emcc -s WASM=0 -s INVOKE_RUN=0 -s ASYNCIFY -I${config.libwallaby.root}/include -L${config.libwallaby.root}/lib -lkipr -o ${path}.js ${path}`, (err, stdout, stderr) => {
+    exec(`emcc -s WASM=0 -s INVOKE_RUN=0 -s ASYNCIFY -s EXIT_RUNTIME=1 -s "EXPORTED_FUNCTIONS=['_main', '_simMainWrapper']" -I${config.libwallaby.root}/include -L${config.libwallaby.root}/lib -lkipr -o ${path}.js ${path}`, (err, stdout, stderr) => {
       if (err) {
         return res.status(400).json({
           stdout,

--- a/express.js
+++ b/express.js
@@ -33,14 +33,17 @@ app.post('/compile', (req, res) => {
     });
   }
 
+  // Wrap user's main() in our own "main()" that exits properly
+  // Required because Asyncify keeps emscripten runtime alive, which would prevent cleanup code from running
   const augmentedCode = req.body.code + `
-  #include <emscripten.h>
- 
-  void simMainWrapper()
-  {
-    main();
-    emscripten_force_exit(0);
-  }`;
+    #include <emscripten.h>
+  
+    void simMainWrapper()
+    {
+      main();
+      emscripten_force_exit(0);
+    }
+  `;
 
   
   const id = uuid();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -53,11 +53,6 @@ ctx.onmessage = (e) => {
 
       mod.onRuntimeInitialized = () => {
         mod._simMainWrapper();
-        // TODO: Had to remove this because _main() is no longer synchronous
-        //       Need to implement some way of knowing when _main() actually ends
-        // ctx.postMessage({
-        //   type: 'program-ended'
-        // })
       };
 
       ctx.postMessage({

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -52,7 +52,7 @@ ctx.onmessage = (e) => {
       );
 
       mod.onRuntimeInitialized = () => {
-        mod._main();
+        mod._simMainWrapper();
         // TODO: Had to remove this because _main() is no longer synchronous
         //       Need to implement some way of knowing when _main() actually ends
         // ctx.postMessage({
@@ -74,7 +74,7 @@ ctx.onmessage = (e) => {
       );
 
       mod.onRuntimeInitialized = () => {
-        mod._main();
+        mod._simMainWrapper();
         ctx.postMessage({
           type: 'program-ended'
         })


### PR DESCRIPTION
Fixes #17 by wrapping the user program's `main()` in our own function that forces the emscripten runtime to exit after `main()`. This triggers cleanup logic in libwallaby to run after the user program ends, meaning motors will auto-stop, servos will auto-disable, etc.