### PR TITLE
Fix misalignment between physics colliders and bot meshes

### DIFF
--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -7,32 +7,32 @@ import { ETSensorBabylon } from './sensors/etSensorBabylon';
 import { RobotState } from './RobotState';
 
 export class Space {
-	public engine: Babylon.Engine;
-	public canvas: HTMLCanvasElement;
-	public scene: Babylon.Scene;
+	private engine: Babylon.Engine;
+	private canvas: HTMLCanvasElement;
+	private scene: Babylon.Scene;
 
 	private getRobotState: () => RobotState;
 	private setRobotState: (robotState: RobotState) => void;
 
 	private ground: Babylon.Mesh;
 
-	public botbody: Babylon.Mesh;
-	public wombat: Babylon.Mesh;
-	public battery: Babylon.Mesh;
-	public caster: Babylon.Mesh;
+	private botbody: Babylon.Mesh;
+	private wombat: Babylon.Mesh;
+	private battery: Babylon.Mesh;
+	private caster: Babylon.Mesh;
 
-	public armServo: Babylon.Mesh;
-	public liftArm: Babylon.Mesh;
-	public servoArmMotor: Babylon.Mesh;
+	private armServo: Babylon.Mesh;
+	private liftArm: Babylon.Mesh;
+	private servoArmMotor: Babylon.Mesh;
 	private servoArmAxis = new Babylon.Vector3(-1.1,3.2,11.97);
 
-	public wheel1: Babylon.Mesh;
-	public wheel2: Babylon.Mesh;
+	private wheel1: Babylon.Mesh;
+	private wheel2: Babylon.Mesh;
 	
-	public motor1: number;
-	public motor2: number;
-	public can: Babylon.Mesh;
-	public can_positions: Array<number>
+	private motor1: number;
+	private motor2: number;
+	private can: Babylon.Mesh;
+	private can_positions: Array<number>
 
 	public generateCans(canPosition: number) {
 		const canName = `Can${canPosition}`;
@@ -73,21 +73,21 @@ export class Space {
 		this.motor2 = -2;
 	}
 
-	public wheel1_joint = new Babylon.MotorEnabledJoint(Babylon.PhysicsJoint.HingeJoint,{
+	private wheel1_joint = new Babylon.MotorEnabledJoint(Babylon.PhysicsJoint.HingeJoint,{
 		mainPivot: new Babylon.Vector3(7.9,-0.34,5.1),//Point relative to the center of the base object
 		connectedPivot: new Babylon.Vector3(0,0,0),//Point relative to the center of the rotating object
 		mainAxis: new Babylon.Vector3(1,0,0),//Base object axis of rotation
 		connectedAxis: new Babylon.Vector3(0,-1,0)//Rotating object axis of rotation (don't forget about any rotations you may have made)
 	});
 
-	public wheel2_joint = new Babylon.MotorEnabledJoint(Babylon.PhysicsJoint.HingeJoint,{
+	private wheel2_joint = new Babylon.MotorEnabledJoint(Babylon.PhysicsJoint.HingeJoint,{
 		mainPivot: new Babylon.Vector3(-7.9,-0.34,5.1),
 		connectedPivot: new Babylon.Vector3(0,0,0),
 		mainAxis: new Babylon.Vector3(1,0,0),
 		connectedAxis: new Babylon.Vector3(0,1,0)
 	});
 
-	public liftArm_joint = new Babylon.MotorEnabledJoint(Babylon.PhysicsJoint.HingeJoint,{
+	private liftArm_joint = new Babylon.MotorEnabledJoint(Babylon.PhysicsJoint.HingeJoint,{
 		mainPivot: this.servoArmAxis,
 		connectedPivot: new Babylon.Vector3(0,0,0),
 		mainAxis: new Babylon.Vector3(1,0,0),
@@ -364,7 +364,7 @@ export class Space {
 		this.wheel2.isVisible = this.collidersVisible;
 	}
 
-	public assignPhysicsImpostors () {
+	private assignPhysicsImpostors () {
 		this.liftArm.physicsImpostor = new Babylon.PhysicsImpostor(this.liftArm, Babylon.PhysicsImpostor.BoxImpostor, {mass: 2}, this.scene);
 		this.servoArmMotor.physicsImpostor = new Babylon.PhysicsImpostor(this.servoArmMotor, Babylon.PhysicsImpostor.CylinderImpostor, {mass: 0.1}, this.scene);
 		
@@ -384,7 +384,7 @@ export class Space {
 		this.botbody.physicsImpostor.addJoint(this.wheel2.physicsImpostor,this.wheel2_joint);
 	}
 
-	public assignVisWheels () {
+	private assignVisWheels () {
 		this.scene.getMeshByID('pw-mt11040').setParent(this.wheel1);
 		this.scene.getMeshByID('black high gloss plastic').setParent(this.wheel1);
 		this.scene.getMeshByID('matte rubber').setParent(this.wheel1);
@@ -394,14 +394,14 @@ export class Space {
 		this.scene.getMeshByID('matte rubber.2').setParent(this.wheel2);
 	}
 
-	public assignVisServoArm () {
+	private assignVisServoArm () {
 		// this.scene.getTransformNodeByID('1 x 5 Servo Horn-1').getChildMeshes().forEach(element => {
 		// 	element.setParent(this.servoArmMotor);
 		// });
 		this.scene.getTransformNodeByID('1 x 5 Servo Horn-1').setParent(this.servoArmMotor);
 	}
 
-	public setMotors(m1:number, m2:number){
+	private setMotors(m1:number, m2:number){
 		this.motor1 = m1;
 		this.motor2 = m2;
 		

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -26,9 +26,9 @@ export class Space {
 	private wheel1: Babylon.Mesh;
 	private wheel2: Babylon.Mesh;
 
-	private wheel1_joint: Babylon.IMotorEnabledJoint;
-	private wheel2_joint: Babylon.IMotorEnabledJoint;
-	private liftArm_joint: Babylon.IMotorEnabledJoint;
+	private wheel1_joint: Babylon.MotorEnabledJoint;
+	private wheel2_joint: Babylon.MotorEnabledJoint;
+	private liftArm_joint: Babylon.MotorEnabledJoint;
 
 	// TODO: Associate each sensor with an update frequency, since we may update different sensors at different speeds
 	private etSensorFake: VisibleSensor;

--- a/src/components/SimulatorArea.tsx
+++ b/src/components/SimulatorArea.tsx
@@ -15,7 +15,6 @@ interface SimulatorAreaState { }
 
 export class SimulatorArea extends React.Component<SimulatorAreaProps, SimulatorAreaState> {
     canvas: HTMLCanvasElement;
-    engine: Babylon.Engine;
     space: Sim.Space;
     
     constructor(props: SimulatorAreaProps) {
@@ -24,36 +23,18 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps, Simulator
     }
 
     componentDidMount() {
-        this.engine = new Babylon.Engine(this.canvas, true, { preserveDrawingBuffer: true, stencil: true });
-        this.space = new Sim.Space(this.engine, this.canvas, () => this.props.robotState, (robotState) => {
+        this.space = new Sim.Space(this.canvas, () => this.props.robotState, (robotState) => {
             this.props.onRobotStateChange(robotState);
+        });
+
+        // Resize Babylon engine when canvas is resized
+        this.canvas.addEventListener('resize', () => {
+            this.space.handleResize();
         });
         
         this.space.createScene();
         this.space.loadMeshes();
-
-        this.space.scene.registerAfterRender(() => {
-            let m1 = this.props.robotState.motor0_speed  / 1500 * -2;
-            let m2 = this.props.robotState.motor3_speed  / 1500 * -2;
-            this.space.setMotors(m1, m2);
-            // space.setMotors(m1,m2);
-
-            // if(this.registers_[61] == 0){
-            // 	s1 = WorkerInstance.readServoRegister(WorkerInstance.registers[78], WorkerInstance.registers[79]);
-            // 	s3 = WorkerInstance.readServoRegister(WorkerInstance.registers[80], WorkerInstance.registers[81]);
-            // }
-        });
-
-        this.engine.runRenderLoop(() => {
-            this.space.scene.render();
-        })
-
-        // Resize Babylon engine when canvas is resized
-        this.canvas.addEventListener('resize', () => {
-            if (this.engine) {
-                this.engine.resize();
-            }
-        });
+        this.space.startRenderLoop();
     }
 
     componentDidUpdate(prevProps: SimulatorAreaProps) {

--- a/src/components/SimulatorArea.tsx
+++ b/src/components/SimulatorArea.tsx
@@ -1,5 +1,4 @@
 import React = require("react");
-import * as Babylon from 'babylonjs';
 
 import * as Sim from '../Sim';
 import { RobotState } from "../RobotState";

--- a/src/components/SimulatorArea.tsx
+++ b/src/components/SimulatorArea.tsx
@@ -53,7 +53,7 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps, Simulator
 
     setCanEnabled(canNumber: number, isEnabled: boolean) {
         isEnabled
-            ? this.space.generateCans(canNumber + 1)
+            ? this.space.createCan(canNumber + 1)
             : this.space.destroyCan(canNumber + 1);
     }
 


### PR DESCRIPTION
Fixes #29 by ensuring that the physics imposters aren't created/assigned until after the bot meshes have loaded. This allows the meshes to align properly before gravity starts acting on the imposters.