### PR TITLE
Automated Installation and Improved Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Simulates a botball/JBC style demobot with a built in IDE.
 ## Automated Setup
 Navigate to the root of this repository (cd /path/to/simulator/)
 ```bash
+sudo chmod 777 install.sh
 sudo ./install.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@ Simulator for the Wombats.
 ### Requirements
 - [Node.js](https://nodejs.org/)
 - [yarn](https://classic.yarnpkg.com/)
+- Doxygen (libwallaby requirement)
+
+```bash
+sudo apt-get install nodejs
+sudo apt-get install doxygen
+sudo npm install --global npm
+sudo npm install --global yarn
+yarn --version
+
+#(if yarn does not work, reboot or use "sudo yarn" on the rest of the instructions)
+```
+
+If you do not have cmake and make:
+```bash
+sudo apt-get install cmake
+sudo apt-get install build-essential
+```
 
 ### Install Emscripten
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # Simulator
-Simulator for the Wombats.
+A Robotics Simulator built in typescript.
+Simulates a botball/JBC style demobot with a built in IDE.
 
 # Development
 
-## Initial Setup
+## Automated Setup
+Navigate to the root of this repository (cd /path/to/simulator/)
+```bash
+sudo ./install.sh
+```
+
+## Manual Setup
 
 ### Requirements
 - [Node.js](https://nodejs.org/)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+cd .. #fix directory to be outside simulator
+mkdir simulator_server
+cp -r simulator simulator_server
+cd simulator_server
+
+#Install all the prerequisit software
+echo
+echo Install all the prerequisit software...
+echo
+
+sudo apt-get update
+sudo apt-get upgrade
+sudo apt-get install nodejs -y
+sudo apt-get install doxygen -y
+sudo apt-get install npm -y
+sudo apt-get install node -y
+sudo npm install --global npm
+sudo npm install --global yarn
+yarn --version
+
+
+#Just in case, install cmake and make...
+echo
+echo Just in case, install cmake and make...
+echo
+
+sudo apt-get install cmake
+sudo apt-get install build-essential
+
+
+#Install emscripten
+echo
+echo Install emscripten..
+echo
+
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+./emsdk install latest
+./emsdk activate latest
+cd ..
+
+
+#Download and install simulator
+echo
+echo Download and install simulator
+echo
+
+git clone https://github.com/kipr/simulator.git
+cd simulator
+yarn install
+cd ..
+
+
+#Install libwallaby (emscripten version)
+echo
+echo "Install libwallaby (emscripten version)"
+echo
+
+git clone --branch emscripten https://github.com/kipr/libwallaby.git
+mkdir libwallaby/build
+
+#Fix directory and add emsdk_env.sh to $PATH temporarily
+echo
+echo "Fix directory and add emsdk_env.sh to PATH temporarily"
+echo
+
+cd emsdk
+source emsdk_env.sh
+cd ..
+
+
+#Build Libwallaby (with emscripten)
+echo
+echo "Build Libwallaby (with emscripten)"
+echo
+
+cd libwallaby/build
+emcmake cmake -Dwith_vision_support=OFF -Dwith_graphics_support=OFF -Dno_wallaby=ON -Dbuild_python=OFF .. -DJS_ONLY=ON
+emmake make -j8
+cd ../..
+
+
+#Run the Server in parralel
+sudo chmod 777 simulator/runServer.sh
+cd simulator
+sudo ./runServer.sh &
+cd ..
+
+#Build Simulator in watch mode and run in background
+echo
+echo Build Simulator in watch mode and run in background
+echo
+
+cd simulator
+yarn watch
+
+

--- a/runServer.sh
+++ b/runServer.sh
@@ -8,5 +8,5 @@ pwd
 cd emsdk
 source emsdk_env.sh
 cd ../simulator
-LIBWALLABY_ROOT=../libwallaby/build node express.js
+LIBWALLABY_ROOT=../libwallaby node express.js
 

--- a/runServer.sh
+++ b/runServer.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd ..
+
+#Run the server
+sleep 5
+pwd
+cd emsdk
+source emsdk_env.sh
+cd ../simulator
+LIBWALLABY_ROOT=../libwallaby/build node express.js
+


### PR DESCRIPTION
I created a script that will install and run the simulator server automatically.
This will work from a fresh install of linux. It downloads *everything* required.

All you have to do is "sudo ./install.sh" and it goes off.
(may need to chmod 777 to fix permissions)

The installation instructions were also missing some steps (out of assumption) so I added some extra steps so even a layman teacher would be able to set it up on their PC

I have not yet gotten it to work on the Pi, I don't even think I have gotten the Pi to work manually.

(note: A PC will not have this issue)
This is the output on a **Pi**:
```bash
npm WARN engine npm@7.6.3: wanted: {"node":">=10"} (current: {"node":"0.10.29","npm":"1.4.21"})
npm WARN package.json minipass-collect@1.0.2 No repository field.
npm WARN package.json minipass-pipeline@1.2.4 No repository field.
npm WARN package.json promise-all-reject-late@1.0.1 No repository field.
npm ERR! Error: Method Not Allowed
npm ERR!     at errorResponse (/usr/share/npm/lib/cache/add-named.js:260:10)
npm ERR!     at /usr/share/npm/lib/cache/add-named.js:203:12
npm ERR!     at saved (/usr/share/npm/node_modules/npm-registry-client/lib/get.js:167:7)
npm ERR!     at Object.oncomplete (fs.js:107:15)
npm ERR! If you need help, you may report this *entire* log,
npm ERR! including the npm and node versions, at:
npm ERR!     <http://github.com/npm/npm/issues>

npm ERR! System Linux 4.1.19-v7+
npm ERR! command "/usr/bin/nodejs" "/usr/bin/npm" "install" "--global" "npm"
npm ERR! cwd /home/pi/dev/simulator_server
npm ERR! node -v v0.10.29
npm ERR! npm -v 1.4.21
npm ERR! code E405
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/pi/dev/simulator_server/npm-debug.log
npm ERR! not ok code 0
npm WARN engine yarn@1.22.10: wanted: {"node":">=4.0.0"} (current: {"node":"0.10.29","npm":"1.4.21"})

```