### PR TITLE
Fix "compile succeeded" bug + don't run on compile

### DIFF
--- a/src/WorkerInstance.ts
+++ b/src/WorkerInstance.ts
@@ -162,16 +162,6 @@ class WorkerInstance {
     });
   }
 
-  compile(code: string) {
-    this.worker_.postMessage({
-      type: 'stop'
-    });
-    this.worker_.postMessage({
-      type: 'compile',
-      code
-    });
-  }
-
   stop() {
     this.worker_.postMessage({
       type: 'stop'

--- a/src/WorkerProtocol.ts
+++ b/src/WorkerProtocol.ts
@@ -10,12 +10,7 @@ export namespace Protocol {
       hello: string;
     }
 
-    export interface CompileRequest {
-      type: 'compile';
-      code: string;
-    }
-
-    export type Request = StartRequest | StopRequest | CompileRequest | SetRegisterRequest | ProgramEndedRequest | ProgramOutputRequest | ProgramErrorRequest | SetMotorPositionRequest;
+    export type Request = StartRequest | StopRequest | SetRegisterRequest | ProgramEndedRequest | ProgramOutputRequest | ProgramErrorRequest | SetMotorPositionRequest;
 
     export interface StartResponse {
       type: 'start';
@@ -23,10 +18,6 @@ export namespace Protocol {
 
     export interface StopResponse {
       type: 'stop';
-    }
-
-    export interface CompileResponse {
-      type: 'compile';
     }
 
     export interface ProgramEndedRequest {
@@ -37,7 +28,7 @@ export namespace Protocol {
       type: 'program-ended'
     }
 
-    export type Response = StartResponse | StopResponse | CompileResponse | SetRegisterResponse | ProgramEndedResponse;
+    export type Response = StartResponse | StopResponse | SetRegisterResponse | ProgramEndedResponse;
 
 
     export interface SetRegisterRequest {

--- a/src/components/SimulatorSidebar.tsx
+++ b/src/components/SimulatorSidebar.tsx
@@ -40,6 +40,10 @@ export class SimulatorSidebar extends React.Component<Props, State> {
       code: '#include <stdio.h>\n#include <kipr/wombat.h>\n\nint main()\n{\n  printf("Hello, World!\\n");\n  return 0;\n}\n',
       console: '',
     };
+
+    // Set handlers for program output
+    WorkerInstance.onStdOutput = this.onStdOutput_;
+    WorkerInstance.onStdError = this.onStdError_;
   }
 
   private onStdOutput_ = (s: string) => {
@@ -80,8 +84,6 @@ export class SimulatorSidebar extends React.Component<Props, State> {
     const compiledCode = await this.compileCurrentCode();
     if (compiledCode === null) return;
 
-    WorkerInstance.onStdOutput = this.onStdOutput_;
-    WorkerInstance.onStdError = this.onStdError_;
     WorkerInstance.start(compiledCode);
   };
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -63,25 +63,6 @@ ctx.onmessage = (e: MessageEvent) => {
       break;
     }
 
-    case 'compile': {
-      const mod = dynRequire(message.code,{},
-        print,
-        err
-      );
-
-      mod.onRuntimeInitialized = () => {
-        mod._simMainWrapper();
-        ctx.postMessage({
-          type: 'program-ended'
-        });
-      };
-
-      ctx.postMessage({
-        type: 'compile'
-      });
-
-      break;
-    }
     case 'setregister': {
       registers[message.address] = message.value;
 


### PR DESCRIPTION
Main changes
- [fixes #53] On compile, `SimulatorSidebar` directly displays the "Compile succeeded" message instead of showing it through `onStdOutput()`. This fixes a bug where "Compile succeeded" wasn't being shown in some cases
- [fixes #52] Clicking "compile" no longer runs the user program