### PR TITLE
Fix stderr output in output box

### DIFF
--- a/src/components/SimulatorSidebar.tsx
+++ b/src/components/SimulatorSidebar.tsx
@@ -55,10 +55,11 @@ export class SimulatorSidebar extends React.Component<Props, State> {
   };
 
   private onStdError_ = (stderror: string) => {
-    this.setState({
-      console: `${stderror}\n Compiled`
-    });
+    this.setState(prevState => ({
+      console: `${prevState.console}\n${stderror}`,
+    }));
   };
+
   private onCompileClick_: React.MouseEventHandler<HTMLButtonElement> = async () => {    
     try {
       const compiled = await compile(this.state.code);

--- a/src/require.ts
+++ b/src/require.ts
@@ -1,7 +1,7 @@
 export interface EmscriptenModule {
   context: ModuleContext,
   print: (s: string) => void,
-  err: (stdout: string, stderror: string) => void,
+  printErr: (stderror: string) => void,
   onRuntimeInitialized?: () => void,
   _simMainWrapper?: () => void,
 }
@@ -13,11 +13,11 @@ export interface ModuleContext {
   getMotorPosition?: (port: number) => void,
 }
 
-export default (code: string, context: ModuleContext, print: (s: string) => void, err: (stdout: string, stderror: string) => void): EmscriptenModule => {
+export default (code: string, context: ModuleContext, print: (s: string) => void, printErr: (stderror: string) => void): EmscriptenModule => {
   const mod: EmscriptenModule = {
     context,
     print,
-    err 
+    printErr,
   };
 
   // Disable eslint rule - dynamic evaluation of user code is needed here

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,7 +12,7 @@ const print = (s: string) => {
     stdoutput: s
   });
 };
-const err = (stdoutput: string, stderror: string) => {
+const printErr = (stderror: string) => {
   ctx.postMessage({
     type: 'programerror',
     stderror: stderror
@@ -49,7 +49,7 @@ ctx.onmessage = (e: MessageEvent) => {
         },
       },
       print,
-      err
+      printErr
       );
 
       mod.onRuntimeInitialized = () => {
@@ -66,7 +66,7 @@ ctx.onmessage = (e: MessageEvent) => {
     case 'compile': {
       const mod = dynRequire(message.code,{},
         print,
-        err
+        printErr
       );
 
       mod.onRuntimeInitialized = () => {


### PR DESCRIPTION
Main changes
- [fixes #59] Pass the correct `printErr` property to emscripten's `Module`. This fixes a bug where `stderr` output didn't appear in simulator.