### PR TITLE
Fix warnings about deprecated morgan usage

### DIFF
--- a/express.js
+++ b/express.js
@@ -18,7 +18,7 @@ app.use((req, res, next) => {
 });
 
 app.use(bodyParser.json());
-app.use(morgan());
+app.use(morgan('combined'));
 
 app.post('/compile', (req, res) => {
   // const body = JSON.parse();


### PR DESCRIPTION
Main changes
- [fixes #62] Pass an explicit format type to `morgan` to prevent deprecated usage.