### PR TITLE
Auto-align collider meshes

### DIFF
--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -26,7 +26,7 @@ export class Space {
   private can: Babylon.Mesh;
   private canCoordinates: Array<[number, number]>;
 
-  private collidersVisible = true;
+  private collidersVisible = false;
 
   private readonly TICKS_BETWEEN_ET_SENSOR_UPDATES = 15;
 
@@ -124,11 +124,11 @@ export class Space {
     this.scene.getTransformNodeByName('Root').setAbsolutePosition(new Babylon.Vector3(0, 5.7, 0));
     this.scene.getTransformNodeByName('Root').scaling.scaleInPlace(100);
     
-    // Hide collider meshes
+    // Hide collider meshes (unless enabled for debugging)
     importMeshResult.meshes.forEach(mesh => {
       if (mesh.name.startsWith('collider')) {
-        mesh.isVisible = false;
-        // mesh.visibility = 0.6; // Partial visibility is useful for debugging
+        mesh.visibility = 0.6;
+        mesh.isVisible = this.collidersVisible;
       }
     });
 

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -117,10 +117,11 @@ export class Space {
     const importMeshResult = await Babylon.SceneLoader.ImportMeshAsync("",'static/', 'Simulator_Demobot_colliders.glb', this.scene);
 
     // TEMP FIX: Scale everything up by 100 to avoid Ammo issues at small scale
-    // Also have to apply transformations to 'Root' node b/c when visual transform nodes are unparented, they lose their transformations
-    // (seems to be fixed in Babylon 5 alpha versions)
     const rootMesh = importMeshResult.meshes.find(mesh => mesh.name === '__root__');
     rootMesh.scaling.scaleInPlace(100);
+
+    // Also have to apply transformations to 'Root' node b/c when visual transform nodes are unparented, they lose their transformations
+    // (seems to be fixed in Babylon 5 alpha versions)
     this.scene.getTransformNodeByName('Root').setAbsolutePosition(new Babylon.Vector3(0, 5.7, 0));
     this.scene.getTransformNodeByName('Root').scaling.scaleInPlace(100);
     
@@ -214,6 +215,7 @@ export class Space {
     });
     this.bodyCompoundRootMesh.physicsImpostor.addJoint(colliderLeftWheelMesh.physicsImpostor, this.leftWheelJoint);
 
+    // Create ET sensors, positioned relative to other meshes
     const etSensorMesh = this.scene.getMeshByID('black satin finish plastic');
     this.etSensorArm = new ETSensorBabylon(this.scene, etSensorMesh, new Babylon.Vector3(0.0, 0.02, 0.0), new Babylon.Vector3(0.02, 0.02, -0.015), { isVisible: true });
     this.etSensorFake = new ETSensorBabylon(this.scene, this.bodyCompoundRootMesh, new Babylon.Vector3(0, 0, 18), new Babylon.Vector3(0, 0, 18), { isVisible: true });

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -143,6 +143,13 @@ export class Space {
 
     type ColliderShape = 'box' | 'sphere';
     const bodyColliderMeshInfos: [string, ColliderShape][] = [
+      ['collider_arm_claw_1', 'box'],
+      ['collider_arm_claw_2', 'box'],
+      ['collider_arm_claw_3', 'box'],
+      ['collider_claw_1', 'box'],
+      ['collider_claw_2', 'box'],
+      ['collider_claw_3', 'box'],
+      ['collider_claw_servo', 'box'],
       ['collider_body', 'box'],
       ['collider_body_back_panel', 'box'],
       ['collider_body_front_panel', 'box'],


### PR DESCRIPTION
Main changes
- [fixes #46] Add collider meshes to the demobot `glb` model
- [fixes #46] When setting up the Babylon scene, use collider meshes from the model instead of manually creating/positioning new meshes
- Disabling the arm servo logic for now since the arm joints don't exist yet