### PR TITLE
Update scripts / README to use libwallaby master

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ yarn install
 
 ### Build libwallaby for JavaScript
 
-Clone `libwallaby` on the `emscripten` branch:
+Clone `libwallaby`:
 ```bash
-git clone --branch emscripten https://github.com/kipr/libwallaby.git
+git clone https://github.com/kipr/libwallaby.git
 mkdir libwallaby/build
 cd libwallaby/build
 ```
@@ -64,7 +64,7 @@ cd libwallaby/build
 Then build:
 ```bash
 source $PATH_TO_EMSDK/emsdk_env.sh
-emcmake cmake -Dwith_vision_support=OFF -Dwith_graphics_support=OFF -Dno_wallaby=ON -Dbuild_python=OFF .. -DJS_ONLY=ON
+emcmake cmake -Demscripten=ON -Dno_wallaby=ON -Dwith_vision_support=OFF -Dbuild_python=OFF -DBUILD_DOCUMENTATION=OFF ..
 emmake make -j8
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -53,12 +53,12 @@ yarn install
 cd ..
 
 
-#Install libwallaby (emscripten version)
+#Install libwallaby
 echo
-echo "Install libwallaby (emscripten version)"
+echo "Install libwallaby"
 echo
 
-git clone --branch emscripten https://github.com/kipr/libwallaby.git
+git clone https://github.com/kipr/libwallaby.git
 mkdir libwallaby/build
 
 #Fix directory and add emsdk_env.sh to $PATH temporarily
@@ -71,13 +71,13 @@ source emsdk_env.sh
 cd ..
 
 
-#Build Libwallaby (with emscripten)
+#Build Libwallaby (for emscripten)
 echo
-echo "Build Libwallaby (with emscripten)"
+echo "Build Libwallaby (for emscripten)"
 echo
 
 cd libwallaby/build
-emcmake cmake -Dwith_vision_support=OFF -Dwith_graphics_support=OFF -Dno_wallaby=ON -Dbuild_python=OFF .. -DJS_ONLY=ON
+emcmake cmake -Demscripten=ON -Dno_wallaby=ON -Dwith_vision_support=OFF -Dbuild_python=OFF -DBUILD_DOCUMENTATION=OFF ..
 emmake make -j8
 cd ../..
 


### PR DESCRIPTION
Main changes:
- [fixes #76] Update README and `install.sh` script to refer to libwallaby `master` branch