### PR TITLE
Calculate motor positions based on wheel rotation

### DIFF
--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -427,8 +427,8 @@ export class Space {
     // One motor is negative because the wheel joints are created on opposite axes,
     // so one needs to turn "backwards" for them to turn in the same direction
     if (this.leftWheelJoint && this.rightWheelJoint) {
-      this.leftWheelJoint.setMotor(leftSpeed / 1500 * 5);
-      this.rightWheelJoint.setMotor(-rightSpeed / 1500 * 5);
+      this.leftWheelJoint.setMotor(leftSpeed / 315);
+      this.rightWheelJoint.setMotor(-rightSpeed / 315);
     }
   }
 


### PR DESCRIPTION
This PR fixes #85 by updating motor positions based on actual wheel rotation.

One quirk this introduces is that the motor positions will slowly drift even when the motors aren't on. This is because there's always a slight drift when the robot is sitting still. This isn't a new issue, but it's more apparent now in the motor positions. I'll create a new issue for this.