### PR TITLE
Specify emscripten version in install script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ See more info here: https://emscripten.org/docs/getting_started/downloads.html
 ```bash
 git clone https://github.com/emscripten-core/emsdk.git
 cd emsdk
-./emsdk install latest
-./emsdk activate latest
+./emsdk install 2.0.2
+./emsdk activate 2.0.2
 ```
 
 ### Install Dependencies

--- a/install.sh
+++ b/install.sh
@@ -37,8 +37,8 @@ echo
 
 git clone https://github.com/emscripten-core/emsdk.git
 cd emsdk
-./emsdk install latest
-./emsdk activate latest
+./emsdk install 2.0.2
+./emsdk activate 2.0.2
 cd ..
 
 


### PR DESCRIPTION
This PR updates the install script and README to use emscripten `2.0.2` instead of `latest`. This should make deployments more predictable and avoid random things breaking due to emscripten updates.

See #81 for details on why this specific version is the most recent version we can use. Once that issue is resolved for a newer version of emscripten, we can update to that newer version.