### PR TITLE
Prevent NaN values in position inputs

### DIFF
--- a/src/components/NumberDisplay.tsx
+++ b/src/components/NumberDisplay.tsx
@@ -11,7 +11,10 @@ type Props = NumberDisplayProps;
 
 export class NumberDisplay extends React.Component<Props> {
   private onValueChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    this.props.onChange(Number.parseInt(event.target.value));
+    const parsedNumber = event.target.value !== '' ? Number.parseInt(event.target.value) : 0;
+    if (!Number.isNaN(parsedNumber)) {
+      this.props.onChange(parsedNumber);
+    }
   };
 
   render(): React.ReactNode {


### PR DESCRIPTION
Fixes #83 by checking if the user enters a non-number in the position input boxes. Empty strings turn into 0, while everything else remains at the previous value.