### PR TITLE
Set robot position using `TransformNode`

### DIFF
--- a/src/RobotState.ts
+++ b/src/RobotState.ts
@@ -6,9 +6,6 @@ export interface RobotState {
 
   // Units: Radians
   theta: number;
-  
-  // Mesh created
-  mesh: boolean;
 
   // Units: Ticks
   motorSpeeds: [number, number, number, number];
@@ -23,7 +20,6 @@ export namespace RobotState {
     y: 0,
     z: 0,
     theta:0,
-    mesh: true,
     motorSpeeds: [0, 0, 0, 0],
     motorPositions: [0, 0, 0, 0],
     servoPositions: [1024, 1024, 1024, 0],

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -7,6 +7,7 @@ import { SimulatorArea } from './SimulatorArea';
 interface RootState {
   robotState: RobotState,
   isCanEnabled: boolean[],
+  shouldSetRobotPosition: boolean,
 }
 type Props = Record<string, never>;
 type State = RootState;
@@ -17,6 +18,7 @@ export class Root extends React.Component<Props, State> {
     this.state = {
       robotState: WorkerInstance.state,
       isCanEnabled: Array<boolean>(12).fill(false),
+      shouldSetRobotPosition: false,
     };
   }
 
@@ -50,6 +52,14 @@ export class Root extends React.Component<Props, State> {
     });
   };
 
+  private onRobotPositionSetRequested_ = () => {
+    this.setState({ shouldSetRobotPosition: true });
+  };
+
+  private onRobotPositionSetCompleted_ = () => {
+    this.setState({ shouldSetRobotPosition: false });
+  };
+
   render(): React.ReactNode {
     const { state } = this;
 
@@ -57,11 +67,11 @@ export class Root extends React.Component<Props, State> {
       <div id="main">
         <div id="root">
           <section id="app">
-            <SimulatorSidebar robotState={state.robotState} isCanChecked={state.isCanEnabled} onRobotStateChange={this.onRobotStateUpdate_} onCanChange={this.onCanChange_} />
+            <SimulatorSidebar robotState={state.robotState} isCanChecked={state.isCanEnabled} onRobotStateChange={this.onRobotStateUpdate_} onCanChange={this.onCanChange_} onRobotPositionSetRequested={this.onRobotPositionSetRequested_} />
           </section>
         </div>
         <div id="right">
-          <SimulatorArea robotState={state.robotState} canEnabled={state.isCanEnabled} onRobotStateUpdate={this.onRobotStateUpdate_} />
+          <SimulatorArea robotState={state.robotState} canEnabled={state.isCanEnabled} onRobotStateUpdate={this.onRobotStateUpdate_} onRobotPositionSetCompleted={this.onRobotPositionSetCompleted_} shouldSetRobotPosition={state.shouldSetRobotPosition} />
         </div>
       </div>
     );

--- a/src/components/SimulatorArea.tsx
+++ b/src/components/SimulatorArea.tsx
@@ -6,8 +6,10 @@ import { RobotState } from "../RobotState";
 interface SimulatorAreaProps {
   robotState: RobotState;
   canEnabled: boolean[];
+  shouldSetRobotPosition: boolean;
 
   onRobotStateUpdate: (robotState: Partial<RobotState>) => void;
+  onRobotPositionSetCompleted: () => void;
 }
 
 export class SimulatorArea extends React.Component<SimulatorAreaProps> {
@@ -46,9 +48,11 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps> {
         this.setCanEnabled(i, enabled);
       }
     });
-    // Checks to see if robot position has been set
-    if (this.props.robotState.mesh !== prevProps.robotState.mesh) {
-      this.setMeshEnabled(this.props.robotState.mesh);
+
+    // Checks if robot position needs to be set
+    if (this.props.shouldSetRobotPosition && !prevProps.shouldSetRobotPosition) {
+      this.space.resetPosition();
+      this.props.onRobotPositionSetCompleted();
     }
   }
 
@@ -62,23 +66,6 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps> {
     isEnabled
       ? this.space.createCan(canNumber + 1)
       : this.space.destroyCan(canNumber + 1);
-  }
-
-  private setMeshEnabled(isEnabled: boolean) {
-    isEnabled
-      ? this.reloadMeshes()
-      : this.space.destroyBot();
-  }
-
-  private reloadMeshes() {
-    this.space.stopRenderLoop();
-    this.space.loadMeshes()
-      .then(() => {
-        this.space.startRenderLoop();
-      })
-      .catch((e) => {
-        console.error('The simulator meshes failed to load', e);
-      });
   }
 
   render(): React.ReactNode {

--- a/src/components/SimulatorSidebar.tsx
+++ b/src/components/SimulatorSidebar.tsx
@@ -23,6 +23,7 @@ export interface SimulatorSidebarProps extends StyleProps {
 
   onRobotStateChange: (robotState: RobotState) => void;
   onCanChange: (canNumber: number, checked: boolean) => void;
+  onRobotPositionSetRequested: () => void;
 }
 
 interface SimulatorSidebarState {
@@ -116,10 +117,7 @@ export class SimulatorSidebar extends React.Component<Props, State> {
   };
 
   private onSetClick_: React.MouseEventHandler<HTMLButtonElement> = () => {
-    this.props.onRobotStateChange({
-      ...this.props.robotState,
-      mesh: false,
-    });
+    this.props.onRobotPositionSetRequested();
   };
 
   private onResetClick_: React.MouseEventHandler<HTMLButtonElement> = () => {
@@ -129,8 +127,9 @@ export class SimulatorSidebar extends React.Component<Props, State> {
       y: RobotState.empty.y,
       z: RobotState.empty.z,
       theta: RobotState.empty.theta,
-      mesh: false,
     });
+
+    this.props.onRobotPositionSetRequested();
 
     this.setState({
       console: ''


### PR DESCRIPTION
This PR uses a `TransformNode` to set/reset the robot's position instead of recreating the robot. Setting/resetting the position should be smoother/faster now, since the wheels move with the body and the meshes don't need to be reloaded.