### PR TITLE
Add button for stopping the user program

### DIFF
--- a/src/WorkerInstance.ts
+++ b/src/WorkerInstance.ts
@@ -166,9 +166,6 @@ class WorkerInstance {
   
   start(code: string) {
     this.worker_.postMessage({
-      type: 'stop'
-    });
-    this.worker_.postMessage({
       type: 'start',
       code
     });
@@ -182,10 +179,6 @@ class WorkerInstance {
     this.registers_[Registers.REG_RW_MOT_SRV_ALLSTOP] = 0xF0;
 
     this.startWorker();
-
-    this.worker_.postMessage({
-      type: 'stop'
-    });
   }
 
   // TODO: consider only calling postMessage() if register value is different

--- a/src/WorkerInstance.ts
+++ b/src/WorkerInstance.ts
@@ -163,6 +163,7 @@ class WorkerInstance {
       }
     }
   };
+  
   start(code: string) {
     this.worker_.postMessage({
       type: 'stop'
@@ -174,6 +175,14 @@ class WorkerInstance {
   }
 
   stop() {
+    this.worker_.terminate();
+
+    // Reset specific registers to stop motors and disable servos
+    this.registers_[Registers.REG_RW_MOT_MODES] = 0x00;
+    this.registers_[Registers.REG_RW_MOT_SRV_ALLSTOP] = 0xF0;
+
+    this.startWorker();
+
     this.worker_.postMessage({
       type: 'stop'
     });
@@ -228,7 +237,7 @@ class WorkerInstance {
   }
 
   constructor() {
-    this.worker_.onmessage = this.onMessage;
+    this.startWorker();
     requestAnimationFrame(this.tick);
   }
 
@@ -241,7 +250,12 @@ class WorkerInstance {
     return this.state_;
   }
 
-  private worker_ = new Worker('/js/worker.min.js');
+  private startWorker() {
+    this.worker_ = new Worker('/js/worker.min.js');
+    this.worker_.onmessage = this.onMessage;
+  }
+
+  private worker_: Worker;
 }
 
 export default new WorkerInstance();

--- a/src/WorkerProtocol.ts
+++ b/src/WorkerProtocol.ts
@@ -5,19 +5,10 @@ export namespace Protocol {
       code: string;
     }
 
-    export interface StopRequest {
-      type: 'stop';
-      hello: string;
-    }
-
-    export type Request = StartRequest | StopRequest | SetRegisterRequest | ProgramEndedRequest | ProgramOutputRequest | ProgramErrorRequest;
+    export type Request = StartRequest | SetRegisterRequest | ProgramEndedRequest | ProgramOutputRequest | ProgramErrorRequest;
 
     export interface StartResponse {
       type: 'start';
-    }
-
-    export interface StopResponse {
-      type: 'stop';
     }
 
     export interface ProgramEndedRequest {
@@ -28,7 +19,7 @@ export namespace Protocol {
       type: 'program-ended'
     }
 
-    export type Response = StartResponse | StopResponse | SetRegisterResponse | ProgramEndedResponse;
+    export type Response = StartResponse | SetRegisterResponse | ProgramEndedResponse;
 
 
     export interface SetRegisterRequest {

--- a/src/components/SimulatorSidebar.tsx
+++ b/src/components/SimulatorSidebar.tsx
@@ -92,6 +92,7 @@ export class SimulatorSidebar extends React.Component<Props, State> {
     const compiledCode = await this.compileCurrentCode();
     if (compiledCode === null) return;
 
+    WorkerInstance.stop();
     WorkerInstance.start(compiledCode);
   };
 

--- a/src/components/SimulatorSidebar.tsx
+++ b/src/components/SimulatorSidebar.tsx
@@ -95,6 +95,11 @@ export class SimulatorSidebar extends React.Component<Props, State> {
     WorkerInstance.start(compiledCode);
   };
 
+  private onStopClick_: React.MouseEventHandler<HTMLButtonElement> = () => {
+    WorkerInstance.stop();
+    this.appendToConsole('Program stopped\n');
+  };
+
   private onDownloadClick_: React.MouseEventHandler<HTMLButtonElement> = () => {
     const date = new Date();
     const dateString = `${date.getUTCFullYear().toString()}-${date.getMonth().toString()}-${date.getDay().toString()}`;
@@ -201,6 +206,7 @@ export class SimulatorSidebar extends React.Component<Props, State> {
           <p>
             <button onClick={this.onCompileClick_} disabled={isCompiling}>Compile</button>
             <button onClick={this.onRunClick_} disabled={isCompiling}>Run</button>
+            <button onClick={this.onStopClick_}>Stop</button>
             <button onClick={this.onDownloadClick_}>Download</button>
           </p>
           <CodeMirror value={code} onBeforeChange={this.onCodeChange_} options={options} className="code" />


### PR DESCRIPTION
Fixes #58 by adding a "Stop" button to the sidebar that kills the current worker and starts a new one.

The "Stop" button doesn't have any state (i.e. it's always enabled, even when a program isn't running) because we would need to detect when a program stops running normally. We can look into that separately.