### PR TITLE
Fix physics bugs, including claw collisions

### DIFF
--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -96,7 +96,7 @@ export class Space {
 
     // At 100x scale, gravity should be -9.8 * 100, but this causes weird jitter behavior
     // Full gravity will be -9.8 * 10
-    const gravityVector = new Babylon.Vector3(0, -9.8 * 10, 0);
+    const gravityVector = new Babylon.Vector3(0, -9.8 * 50, 0);
     this.ammo_ = new Babylon.AmmoJSPlugin(true, Ammo);
     this.ammo_.setFixedTimeStep(this.DEFAULT_TIMESTEP / this.TIMESTEP_FACTOR);
     this.scene.enablePhysics(gravityVector, this.ammo_);
@@ -319,11 +319,11 @@ export class Space {
     this.clawRotationDefault = Babylon.Quaternion.Inverse(this.armCompoundRootMesh.rotationQuaternion).multiply(this.clawCompoundRootMesh.rotationQuaternion);
 
     // Set physics impostors for root nodes
-    this.bodyCompoundRootMesh.physicsImpostor = new Babylon.PhysicsImpostor(this.bodyCompoundRootMesh, Babylon.PhysicsImpostor.NoImpostor, { mass: 100, friction: 0.1 }, this.scene);
-    this.colliderLeftWheelMesh.physicsImpostor = new Babylon.PhysicsImpostor(this.colliderLeftWheelMesh, Babylon.PhysicsImpostor.CylinderImpostor, { mass: 10, friction: 5 }, this.scene);
-    this.colliderRightWheelMesh.physicsImpostor = new Babylon.PhysicsImpostor(this.colliderRightWheelMesh, Babylon.PhysicsImpostor.CylinderImpostor, { mass: 10, friction: 5 }, this.scene);
-    this.armCompoundRootMesh.physicsImpostor = new Babylon.PhysicsImpostor(this.armCompoundRootMesh, Babylon.PhysicsImpostor.NoImpostor, { mass: 1, friction: 5 }, this.scene);
-    this.clawCompoundRootMesh.physicsImpostor = new Babylon.PhysicsImpostor(this.clawCompoundRootMesh, Babylon.PhysicsImpostor.NoImpostor, { mass: 0.1, friction: 5 }, this.scene);
+    this.bodyCompoundRootMesh.physicsImpostor = new Babylon.PhysicsImpostor(this.bodyCompoundRootMesh, Babylon.PhysicsImpostor.NoImpostor, { mass: 1126, friction: 0.1 }, this.scene);
+    this.colliderLeftWheelMesh.physicsImpostor = new Babylon.PhysicsImpostor(this.colliderLeftWheelMesh, Babylon.PhysicsImpostor.CylinderImpostor, { mass: 14, friction: 5 }, this.scene);
+    this.colliderRightWheelMesh.physicsImpostor = new Babylon.PhysicsImpostor(this.colliderRightWheelMesh, Babylon.PhysicsImpostor.CylinderImpostor, { mass: 14, friction: 5 }, this.scene);
+    this.armCompoundRootMesh.physicsImpostor = new Babylon.PhysicsImpostor(this.armCompoundRootMesh, Babylon.PhysicsImpostor.NoImpostor, { mass: 132, friction: 5 }, this.scene);
+    this.clawCompoundRootMesh.physicsImpostor = new Babylon.PhysicsImpostor(this.clawCompoundRootMesh, Babylon.PhysicsImpostor.NoImpostor, { mass: 17, friction: 5 }, this.scene);
 
     const servoHornTransform = this.scene.getTransformNodeByID('1 x 5 Servo Horn-2');
     servoHornTransform.computeWorldMatrix();
@@ -446,7 +446,7 @@ export class Space {
 
     const new_can = Babylon.MeshBuilder.CreateCylinder(canName,{ height:10, diameter:6, faceUV: faceUV }, this.scene);
     new_can.material = canMaterial;
-    new_can.physicsImpostor = new Babylon.PhysicsImpostor(new_can, Babylon.PhysicsImpostor.CylinderImpostor, { mass: 1, friction: 5 }, this.scene);
+    new_can.physicsImpostor = new Babylon.PhysicsImpostor(new_can, Babylon.PhysicsImpostor.CylinderImpostor, { mass: 5, friction: 5 }, this.scene);
     new_can.position = new Babylon.Vector3(this.canCoordinates[canNumber - 1][0], 5, this.canCoordinates[canNumber - 1][1]);
   }
 

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -48,7 +48,7 @@ export class Space {
 
   private canCoordinates: Array<[number, number]>;
 
-  private collidersVisible = true;
+  private collidersVisible = false;
 
   private readonly DEFAULT_TIMESTEP = 1 / 60;
   private readonly TIMESTEP_FACTOR = 4;

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -548,9 +548,9 @@ export class Space {
     if (armDeltaNorm < 0.01) {
       this.armJoint.setMotor(0);
     } else if (armDeltaNorm >= 0.001 && armDeltaNorm <= 0.04) {
-      this.armJoint.setMotor(armSign * 0.3 * this.TIMESTEP_FACTOR);
+      this.armJoint.setMotor(armSign * 0.3 * this.TIMESTEP_FACTOR, 8000);
     } else {
-      this.armJoint.setMotor(armSign * 2.38 * this.TIMESTEP_FACTOR);
+      this.armJoint.setMotor(armSign * 1.5 * this.TIMESTEP_FACTOR, 8000);
     }
 
     // Get updated real mesh rotation for claw
@@ -569,9 +569,9 @@ export class Space {
     if (clawDeltaNorm < 0.01) {
       this.clawJoint.setMotor(0);
     } else if (clawDeltaNorm >= 0.001 && clawDeltaNorm <= 0.04) {
-      this.clawJoint.setMotor(clawSign * 0.3 * this.TIMESTEP_FACTOR);
+      this.clawJoint.setMotor(clawSign * 0.3 * this.TIMESTEP_FACTOR, 2000);
     } else {
-      this.clawJoint.setMotor(clawSign * 2.38 * this.TIMESTEP_FACTOR);
+      this.clawJoint.setMotor(clawSign * 1.5 * this.TIMESTEP_FACTOR, 2000);
     }
   }
 


### PR DESCRIPTION
Main changes:
- [fixes #112] Fix negative scaling issue with physics impostors, which was causing a lot of our collision issues, including the claw not being able to pick up cans.
- [fixes #112] Add max force to servos, preventing them from applying essentially unlimited force when objects are in the way (for example, when a can is between the claws).
- Use realistic masses, making arm/claw motion and can collisions more realistic.
- Increase gravity closer to real-world value. This prevents rapid arm motion from lifting the robot off the ground.