### PR TITLE
Remove fake ET sensor

### DIFF
--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -45,8 +45,6 @@ export class Space {
 
   private sensorObjects_: SensorObject[];
 
-  private ticksSinceETSensorUpdate: number;
-
   private canCoordinates: Array<[number, number]>;
 
   private collidersVisible = false;
@@ -83,8 +81,6 @@ export class Space {
 
     this.getRobotState = getRobotState;
     this.updateRobotState = updateRobotState;
-
-    this.ticksSinceETSensorUpdate = 0;
   }
 
   public createScene(): void {

--- a/src/sensors/mappings.ts
+++ b/src/sensors/mappings.ts
@@ -10,7 +10,7 @@ export default {
     type: Sensor.Type.Et,
     forward: new Babylon.Vector3(0.0, 0.02, 0.0),
     origin: new Babylon.Vector3(0.02, 0.02, -0.015),
-    output: Sensor.Output.analog(1),
+    output: Sensor.Output.analog(0),
     maxUpdateFrequency: 15,
   },
   // Front touch sensor

--- a/src/sensors/mappings.ts
+++ b/src/sensors/mappings.ts
@@ -5,14 +5,6 @@ import * as Babylon from 'babylonjs';
 
 // Maps object names to Sensors
 export default {
-  // Fake ET sensor
-  'bodyCompoundMesh': {
-    type: Sensor.Type.Et,
-    forward: new Babylon.Vector3(0, 0, 18),
-    origin: new Babylon.Vector3(0, 0, 18),
-    output: Sensor.Output.analog(0),
-    maxUpdateFrequency: 15,
-  },
   // Arm ET sensor
   'black satin finish plastic': {
     type: Sensor.Type.Et,


### PR DESCRIPTION
Main changes
- [fixes #123] Remove the fake ET sensor on the front of the robot.
- Change the arm ET sensor to analog port 0. Previously the fake sensor used port 0.