### PR TITLE
Verify server env vars + make port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ source $PATH_TO_EMSDK/emsdk_env.sh
 LIBWALLABY_ROOT=/path/to/libwallaby node express.js
 ```
 
+## Configuration
+
+The server can be configured using environment variables. Variables without default values must be provided.
+
+| Variable | Description | Default value |
+| -------- | ----------- | ------------- |
+| `LIBWALLABY_ROOT` | Path to the root directory of libwallaby | |
+| `SERVER_PORT` | The port on which to listen for requests | `3000` |
+| `CACHING_STATIC_MAX_AGE` | The max duration (in ms) to allow static assets to be cached | `3600000` (1 hr) |
+
 ## Linting
 
 The project is set up with [ESLint](https://eslint.org/) for JavaScript/TypeScript linting. You can run ESLint manually by running `yarn lint` at the root.

--- a/config.js
+++ b/config.js
@@ -1,16 +1,28 @@
 /* eslint-env node */
 
 module.exports = {
-  libwallaby: {
-    root: getEnvVarOrDefault('LIBWALLABY_ROOT', null),
+  get: () => {
+    return {
+      libwallaby: {
+        root: getEnvVarOrThrow('LIBWALLABY_ROOT'),
+      },
+      caching: {
+        staticMaxAge: getEnvVarOrDefault('CACHING_STATIC_MAX_AGE', 60 * 60 * 1000),
+      }
+    };
   },
-  caching: {
-    staticMaxAge: getEnvVarOrDefault('CACHING_STATIC_MAX_AGE', 60 * 60 * 1000),
-  }
 };
 
 function getEnvVarOrDefault(variableName, defaultValue) {
   return process.env[variableName] !== undefined
     ? process.env[variableName]
     : defaultValue;
+}
+
+function getEnvVarOrThrow(variableName) {
+  if (process.env[variableName] === undefined) {
+    throw new Error(`Required environment variable is not set: ${variableName}`);
+  }
+
+  return process.env[variableName];
 }

--- a/config.js
+++ b/config.js
@@ -3,8 +3,9 @@
 module.exports = {
   get: () => {
     return {
-      libwallaby: {
-        root: getEnvVarOrThrow('LIBWALLABY_ROOT'),
+      server: {
+        port: getEnvVarOrDefault('SERVER_PORT', 3000),
+        libwallabyRoot: getEnvVarOrThrow('LIBWALLABY_ROOT'),
       },
       caching: {
         staticMaxAge: getEnvVarOrDefault('CACHING_STATIC_MAX_AGE', 60 * 60 * 1000),

--- a/express.js
+++ b/express.js
@@ -7,7 +7,6 @@ const fs = require('fs');
 const uuid = require('uuid');
 const { exec } = require('child_process');
 const app = express();
-const portNumber = 3000;
 const sourceDir = 'dist';
 const { get: getConfig } = require('./config');
 
@@ -65,7 +64,7 @@ app.post('/compile', (req, res) => {
       });
     }
 
-    exec(`emcc -s WASM=0 -s INVOKE_RUN=0 -s ASYNCIFY -s EXIT_RUNTIME=1 -s "EXPORTED_FUNCTIONS=['_main', '_simMainWrapper']" -I${config.libwallaby.root}/include -L${config.libwallaby.root}/lib -lkipr -o ${path}.js ${path}`, (err, stdout, stderr) => {
+    exec(`emcc -s WASM=0 -s INVOKE_RUN=0 -s ASYNCIFY -s EXIT_RUNTIME=1 -s "EXPORTED_FUNCTIONS=['_main', '_simMainWrapper']" -I${config.server.libwallabyRoot}/include -L${config.server.libwallabyRoot}/lib -lkipr -o ${path}.js ${path}`, (err, stdout, stderr) => {
       if (err) {
         return res.status(400).json({
           stdout,
@@ -117,7 +116,7 @@ app.use('*', (req,res) => {
 
 
 
-app.listen(portNumber, () => {
-  console.log(`Express web server started: http://localhost:${portNumber}`);
+app.listen(config.server.port, () => {
+  console.log(`Express web server started: http://localhost:${config.server.port}`);
   console.log(`Serving content from /${sourceDir}/`);
 });

--- a/express.js
+++ b/express.js
@@ -9,7 +9,15 @@ const { exec } = require('child_process');
 const app = express();
 const portNumber = 3000;
 const sourceDir = 'dist';
-const config = require('./config');
+const { get: getConfig } = require('./config');
+
+let config;
+try {
+  config = getConfig();
+} catch (e) {
+  process.exitCode = 1;
+  throw e;
+}
 
 app.use((req, res, next) => {
   res.header("Access-Control-Allow-Origin", "*");


### PR DESCRIPTION
Main changes:
- [fixes #120] Ensure required environment variables (like `LIBWALLABY_ROOT` are specified before starting server
- [fixes #37] Allow server port to be configured using `SERVER_PORT` environment variable