### PR TITLE
Add surface toggle for JBC mat A/ JBC mat B. 

### DIFF
--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -10,6 +10,7 @@ import {
 } from './sensors';
 import { RobotState } from './RobotState';
 import Dict from './Dict';
+import { SurfaceState } from './SurfaceState';
 
 export class Space {
   private engine: Babylon.Engine;
@@ -476,6 +477,17 @@ export class Space {
     groundMaterial.emissiveColor = new Babylon.Color3(0.1,0.1,0.1);
     this.ground.material = groundMaterial;
     this.ground.physicsImpostor = new Babylon.PhysicsImpostor(this.ground, Babylon.PhysicsImpostor.BoxImpostor,{ mass:0, friction: 1 }, this.scene);
+  }
+
+  public rebuildFloor(surfaceState: SurfaceState): void { 
+    this.mat.dispose();
+    this.mat = Babylon.MeshBuilder.CreateGround("mat", { width: surfaceState.surfaceWidth, height: surfaceState.surfaceHeight, subdivisions:2 }, this.scene);
+    this.mat.position.y = -0.8;
+    this.mat.rotate(new Babylon.Vector3(0,1,0),-Math.PI / 2);
+    const matMaterial = new Babylon.StandardMaterial("ground", this.scene);
+    matMaterial.ambientTexture = new Babylon.Texture(surfaceState.surfaceImage,this.scene);
+    this.mat.material = matMaterial;
+    this.mat.physicsImpostor = new Babylon.PhysicsImpostor(this.mat, Babylon.PhysicsImpostor.BoxImpostor,{ mass:0, friction: 1 }, this.scene);
   }
 
   private setDriveMotors(leftSpeed: number, rightSpeed: number) {

--- a/src/SurfaceState.ts
+++ b/src/SurfaceState.ts
@@ -1,0 +1,27 @@
+export interface SurfaceState{ 
+  // Filename
+  surfaceImage: string;
+
+  // Inches
+  surfaceWidth: number;
+  surfaceHeight: number;
+
+  // Display name
+  surfaceName: string; 
+}
+
+export namespace SurfaceStatePresets{
+  export const jbcA: SurfaceState = {
+    surfaceImage: "static/Surface-A.png",
+    surfaceWidth: 118,
+    surfaceHeight: 59,
+    surfaceName: "JBC Mat A"
+  };
+
+  export const jbcB: SurfaceState = {
+    surfaceImage: "static/Surface-B.png",
+    surfaceWidth: 118,
+    surfaceHeight: 59,
+    surfaceName: "JBC Mat B"
+  };
+}

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -3,12 +3,14 @@ import { SimulatorSidebar } from './SimulatorSidebar';
 import WorkerInstance from '../WorkerInstance';
 import { RobotState } from '../RobotState';
 import { SimulatorArea } from './SimulatorArea';
+import { SurfaceState, SurfaceStatePresets } from '../SurfaceState';
 
 interface RootState {
   robotState: RobotState,
   isCanEnabled: boolean[],
   shouldSetRobotPosition: boolean,
   isSensorNoiseEnabled: boolean,
+  surfaceState: SurfaceState,
 }
 type Props = Record<string, never>;
 type State = RootState;
@@ -21,6 +23,7 @@ export class Root extends React.Component<Props, State> {
       isCanEnabled: Array<boolean>(12).fill(false),
       shouldSetRobotPosition: false,
       isSensorNoiseEnabled: false,
+      surfaceState: SurfaceStatePresets.jbcA,
     };
   }
 
@@ -66,6 +69,10 @@ export class Root extends React.Component<Props, State> {
     this.setState({ isSensorNoiseEnabled: enabled });
   };
 
+  private onUpdateSurfaceState_ = (newSurfaceState: SurfaceState) => {
+    this.setState({ surfaceState: newSurfaceState });
+  };
+
   render(): React.ReactNode {
     const { state } = this;
 
@@ -73,12 +80,13 @@ export class Root extends React.Component<Props, State> {
       <div id="main">
         <div id="root">
           <section id="app">
-            <SimulatorSidebar robotState={state.robotState} isCanChecked={state.isCanEnabled} isSensorNoiseEnabled={state.isSensorNoiseEnabled} 
-              onRobotStateChange={this.onRobotStateUpdate_} onCanChange={this.onCanChange_} onRobotPositionSetRequested={this.onRobotPositionSetRequested_} onToggleSensorNoise={this.onToggleSensorNoise_}/>
+            <SimulatorSidebar robotState={state.robotState} isCanChecked={state.isCanEnabled} isSensorNoiseEnabled={state.isSensorNoiseEnabled} surfaceState={state.surfaceState}
+              onRobotStateChange={this.onRobotStateUpdate_} onCanChange={this.onCanChange_} onRobotPositionSetRequested={this.onRobotPositionSetRequested_} onToggleSensorNoise={this.onToggleSensorNoise_}
+              onUpdateSurfaceState={this.onUpdateSurfaceState_}/>
           </section>
         </div>
         <div id="right">
-          <SimulatorArea robotState={state.robotState} canEnabled={state.isCanEnabled} isSensorNoiseEnabled={state.isSensorNoiseEnabled} onRobotStateUpdate={this.onRobotStateUpdate_} onRobotPositionSetCompleted={this.onRobotPositionSetCompleted_} shouldSetRobotPosition={state.shouldSetRobotPosition} />
+          <SimulatorArea robotState={state.robotState} canEnabled={state.isCanEnabled} surfaceState={state.surfaceState} isSensorNoiseEnabled={state.isSensorNoiseEnabled} onRobotStateUpdate={this.onRobotStateUpdate_} onRobotPositionSetCompleted={this.onRobotPositionSetCompleted_} shouldSetRobotPosition={state.shouldSetRobotPosition} />
         </div>
       </div>
     );

--- a/src/components/SimulatorArea.tsx
+++ b/src/components/SimulatorArea.tsx
@@ -2,12 +2,14 @@ import * as React from 'react';
 
 import * as Sim from '../Sim';
 import { RobotState } from "../RobotState";
+import { SurfaceState } from '../SurfaceState';
 
 interface SimulatorAreaProps {
   robotState: RobotState;
   canEnabled: boolean[];
   shouldSetRobotPosition: boolean;
   isSensorNoiseEnabled: boolean;
+  surfaceState: SurfaceState;
 
   onRobotStateUpdate: (robotState: Partial<RobotState>) => void;
   onRobotPositionSetCompleted: () => void;
@@ -55,6 +57,12 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps> {
     if (this.props.isSensorNoiseEnabled !== this.oldIsSensorNoiseEnabled) {
       this.oldIsSensorNoiseEnabled = this.props.isSensorNoiseEnabled;
       this.space.updateSensorOptions(this.props.isSensorNoiseEnabled);
+    }
+
+    // Check if board was reset
+    if (this.props.surfaceState !== prevProps.surfaceState) {
+      this.space.rebuildFloor(this.props.surfaceState);
+      this.space.resetPosition();
     }
 
     // Checks if robot position needs to be set

--- a/src/components/SimulatorSidebar.tsx
+++ b/src/components/SimulatorSidebar.tsx
@@ -15,17 +15,21 @@ import Collapsible from './Collapsible';
 import { MotorsDisplay } from './MotorsDisplay';
 import { ServosDisplay } from './ServosDisplay';
 import { RobotPositionDisplay } from './RobotPositionDisplay';
+import { SurfaceConfig } from './SurfaceConfig';
+import { SurfaceState } from '../SurfaceState';
 
 
 export interface SimulatorSidebarProps extends StyleProps {
   robotState: RobotState;
   isCanChecked: boolean[];
   isSensorNoiseEnabled: boolean;
+  surfaceState: SurfaceState;
 
   onRobotStateChange: (robotState: RobotState) => void;
   onCanChange: (canNumber: number, checked: boolean) => void;
   onRobotPositionSetRequested: () => void;
   onToggleSensorNoise: (enabled: boolean) => void;
+  onUpdateSurfaceState: (surfaceState: SurfaceState) => void;
 }
 
 interface SimulatorSidebarState {
@@ -188,6 +192,10 @@ export class SimulatorSidebar extends React.Component<Props, State> {
     this.props.onToggleSensorNoise(isChecked);
   };
 
+  private onUpdateSurfaceState = (surfaceState: SurfaceState) => {
+    this.props.onUpdateSurfaceState(surfaceState);
+  };
+
   render(): React.ReactNode {
     const { props, state } = this;
     const { robotState } = props;
@@ -253,12 +261,12 @@ export class SimulatorSidebar extends React.Component<Props, State> {
           </ul>
         </Collapsible>
         <Collapsible title="Options">
-          <div>
-            <span>
-              <input type="checkbox" name="sensorNoise" checked={this.props.isSensorNoiseEnabled} onChange={this.onToggleSensorNoise}/>
-              <label>Sensor noise</label>
-            </span>
-          </div>
+          <section>
+            <h3>Robot Configuration</h3>
+            <input type="checkbox" name="sensorNoise" checked={this.props.isSensorNoiseEnabled} onChange={this.onToggleSensorNoise}/>
+            <label>Sensor noise</label>
+          </section>
+          <SurfaceConfig surfaceState={this.props.surfaceState} updateSurfaceAndReset={this.onUpdateSurfaceState} />
         </Collapsible>
       </>
     );

--- a/src/components/SurfaceConfig.tsx
+++ b/src/components/SurfaceConfig.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { SurfaceState, SurfaceStatePresets } from "../SurfaceState";
+
+interface SurfaceConfigProps {
+  surfaceState: SurfaceState;
+
+  updateSurfaceAndReset: (surfaceState: SurfaceState) => void;
+}
+
+interface SurfaceConfigState{
+  selectionValue: string;
+}
+
+type Props = SurfaceConfigProps;
+type State = SurfaceConfigState;
+
+export class SurfaceConfig extends React.Component<Props, State> {
+  constructor(props: SurfaceConfigProps) {
+    super(props);
+    this.state = {
+      selectionValue: SurfaceStatePresets.jbcA.surfaceName,
+    };
+  }
+
+  private updateSurfaceAndReset = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    if (event.target.value === this.props.surfaceState.surfaceName) return;
+    this.setState({ selectionValue: event.target.value });
+    switch (event.target.value) {
+      case SurfaceStatePresets.jbcB.surfaceName:
+        this.props.updateSurfaceAndReset(SurfaceStatePresets.jbcB);
+        break;
+      case SurfaceStatePresets.jbcA.surfaceName:
+      default:
+        this.props.updateSurfaceAndReset(SurfaceStatePresets.jbcA);
+        break;
+    }
+  };
+
+  render(): React.ReactNode {
+    return (
+      <section>
+        <h3>Surface Options</h3>
+        <select value={this.state.selectionValue} onChange={this.updateSurfaceAndReset}>
+          <option value={SurfaceStatePresets.jbcA.surfaceName} >JBC Surface A</option>
+          <option value={SurfaceStatePresets.jbcB.surfaceName} >JBC Surface B</option>
+        </select>
+      </section>
+    );
+  }
+}


### PR DESCRIPTION
Quick implementation of surface switching, resets robot position after switch
SurfaceState could be expanded to include props ex. Botball PVC