### PR TITLE
Made ET ray picking depend on if object isPickable

### DIFF
--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -188,6 +188,7 @@ export class Space {
       if (mesh.name.startsWith('collider')) {
         mesh.visibility = 0.6;
         mesh.isVisible = this.collidersVisible;
+        mesh.isPickable = false;
       }
     });
 
@@ -199,6 +200,7 @@ export class Space {
     this.bodyCompoundRootMesh = new Babylon.Mesh("bodyCompoundMesh", this.scene);
     this.bodyCompoundRootMesh.position = wallabyColliderMesh.getAbsolutePosition().clone();
     this.bodyCompoundRootMesh.rotationQuaternion = new Babylon.Quaternion();
+    this.bodyCompoundRootMesh.isPickable = false;
 
     type ColliderShape = 'box' | 'sphere';
     const bodyColliderMeshInfos: [string, ColliderShape][] = [
@@ -223,6 +225,7 @@ export class Space {
     this.armCompoundRootMesh = new Babylon.Mesh("armCompoundMesh", this.scene);
     this.armCompoundRootMesh.position = clawServoColliderMesh.getAbsolutePosition().clone();
     this.armCompoundRootMesh.rotationQuaternion = new Babylon.Quaternion();
+    this.armCompoundRootMesh.isPickable = false;
 
     const armColliderMeshInfos: [string][] = [
       ['collider_arm_claw_1'],
@@ -240,6 +243,7 @@ export class Space {
     this.clawCompoundRootMesh = new Babylon.Mesh("clawCenterMesh", this.scene);
     this.clawCompoundRootMesh.position = clawCenterMesh.getAbsolutePosition().clone();
     this.clawCompoundRootMesh.rotationQuaternion = new Babylon.Quaternion(0, 0, 0, 1);
+    this.clawCompoundRootMesh.isPickable = false;
 
     const clawColliderMeshInfos: [string][] = [
       ['collider_claw_1'],
@@ -306,6 +310,8 @@ export class Space {
     this.colliderRightWheelMesh.setParent(null);
     this.fixNegativeScaling(this.colliderLeftWheelMesh as Babylon.Mesh);
     this.fixNegativeScaling(this.colliderRightWheelMesh as Babylon.Mesh);
+    this.colliderLeftWheelMesh.isPickable = false;
+    this.colliderRightWheelMesh.isPickable = false;
 
     // Find transform nodes (visual meshes) in scene and parent them to the proper node
     this.scene.getTransformNodeByName('ChassisWombat-1').setParent(this.bodyCompoundRootMesh);

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -450,6 +450,7 @@ export class Space {
     const new_can = Babylon.MeshBuilder.CreateCylinder(canName,{ height:10, diameter:6, faceUV: faceUV }, this.scene);
     new_can.material = canMaterial;
     new_can.physicsImpostor = new Babylon.PhysicsImpostor(new_can, Babylon.PhysicsImpostor.CylinderImpostor, { mass: 5, friction: 5 }, this.scene);
+    new_can.isPickable = true;
     new_can.position = new Babylon.Vector3(this.canCoordinates[canNumber - 1][0], 5, this.canCoordinates[canNumber - 1][1]);
   }
 

--- a/src/sensors/EtSensor.ts
+++ b/src/sensors/EtSensor.ts
@@ -64,7 +64,7 @@ export class EtSensor implements SensorObject {
   }
 
   public getValue(): SensorObject.Value {
-    const hit = this.config_.scene.pickWithRay(this.ray);
+    const hit = this.config_.scene.pickWithRay(this.ray, null);
     let value: number;
     if (!hit.pickedMesh) value = 255;
     else value = this.distanceToSensorValue(hit.distance);


### PR DESCRIPTION
If objects need to collide and be picked by a sensor ray they need to have the isPickable property set to true (default is false). This should prevent rays from colliding with unnecessary objects. Tested against the floor (isPickable false) and cans (isPickable true). Some test code is below if needed.
```c
#include <stdio.h>
#include <kipr/wombat.h>

int main()
{
  printf("Hello, World!\n");
  cmpc(0);
  cmpc(3);
  msleep(2000);
  enable_servos();
  set_servo_position(0,1000);
  msleep(1000);
  printf("Start: %d\n", analog(0));
  set_servo_position(0,1800);
  msleep(1000);
  while(gmpc(0) <1000){
    printf("Update: %d\n", analog(0));
    motor(0,10);
    motor(3,10);
  }
  return 0;
}
```