### PR TITLE
Range of analog sensors is now 0 to 4095

### DIFF
--- a/src/sensors/EtSensor.ts
+++ b/src/sensors/EtSensor.ts
@@ -66,7 +66,7 @@ export class EtSensor implements SensorObject {
   public getValue(): SensorObject.Value {
     const hit = this.config_.scene.pickWithRay(this.ray);
     let value: number;
-    if (!hit.pickedMesh) value = 255;
+    if (!hit.pickedMesh) value = 4095;
     else value = this.distanceToSensorValue(hit.distance);
     if (this.__isNoiseEnabled) value = this.applyNoise(value);
     return SensorObject.Value.u8(value); 
@@ -104,7 +104,7 @@ export class EtSensor implements SensorObject {
 
   // Converts from 3D world distance to sensor output value
   private distanceToSensorValue(distance: number): number {
-    return 255 - Math.floor((distance / this.config_.sensor.maxRange) * 255);
+    return 4095 - Math.floor((distance / this.config_.sensor.maxRange) * 4095);
   }
   
   private applyNoise(value: number): number {
@@ -112,7 +112,7 @@ export class EtSensor implements SensorObject {
     const offset = Math.floor(noise * Math.random() * 2) - noise;
     let noisyValue = value - offset;
     if (noisyValue < 0) noisyValue = 0;
-    else if (noisyValue > 255) noisyValue = 255;
+    else if (noisyValue > 4095) noisyValue = 4095;
     return noisyValue;
   }
 }

--- a/src/sensors/EtSensor.ts
+++ b/src/sensors/EtSensor.ts
@@ -69,7 +69,7 @@ export class EtSensor implements SensorObject {
     if (!hit.pickedMesh) value = 4095;
     else value = this.distanceToSensorValue(hit.distance);
     if (this.__isNoiseEnabled) value = this.applyNoise(value);
-    return SensorObject.Value.u8(value); 
+    return SensorObject.Value.u12(value); 
     
   }
 

--- a/src/sensors/SensorObject.ts
+++ b/src/sensors/SensorObject.ts
@@ -49,7 +49,7 @@ namespace SensorObject {
       export const from = (value: Value): U8 => {
         switch (value.type) {
           case Type.U8: return value;
-          case Type.Bool: return u8(value.value ? 255 : 0);
+          case Type.Bool: return u8(value.value ? 4095 : 0);
         }
       };
     }

--- a/src/sensors/SensorObject.ts
+++ b/src/sensors/SensorObject.ts
@@ -26,36 +26,36 @@ namespace SensorObject {
 
   export namespace Value {
     export enum Type {
-      U8,
+      U12,
       Bool
     }
 
     export namespace Type {
       export const toString = (type: Type): string => {
         switch (type) {
-          case Type.U8: return 'U8';
+          case Type.U12: return 'U12';
           case Type.Bool: return 'Boolean';
           default: return `Unknown (${JSON.stringify(type)})`;
         }
       };
     }
   
-    export interface U8 {
-      type: Type.U8;
+    export interface U12 {
+      type: Type.U12;
       value: number;
     }
 
-    export namespace U8 {
-      export const from = (value: Value): U8 => {
+    export namespace U12 {
+      export const from = (value: Value): U12 => {
         switch (value.type) {
-          case Type.U8: return value;
-          case Type.Bool: return u8(value.value ? 4095 : 0);
+          case Type.U12: return value;
+          case Type.Bool: return u12(value.value ? 4095 : 0);
         }
       };
     }
 
-    export const u8 = (value: number): U8 => ({
-      type: Type.U8,
+    export const u12 = (value: number): U12 => ({
+      type: Type.U12,
       value
     });
   
@@ -68,7 +68,7 @@ namespace SensorObject {
       export const from = (value: Value): Bool => {
         switch (value.type) {
           case Type.Bool: return value;
-          case Type.U8: return bool(value.value > 0);
+          case Type.U12: return bool(value.value > 0);
         }
       };
     }
@@ -82,7 +82,7 @@ namespace SensorObject {
     export const FALSE: Bool = bool(false);
   }
   
-  export type Value = Value.U8 | Value.Bool;
+  export type Value = Value.U12 | Value.Bool;
 
   export const apply = (self: SensorObject, state: Partial<RobotState>): Partial<RobotState> => {
     const { output } = self.sensor;
@@ -103,11 +103,11 @@ namespace SensorObject {
       }
 
       case Sensor.Output.Type.Analog: {
-        const u8Value = Value.U8.from(value);
+        const u12Value = Value.U12.from(value);
 
         ret.analogValues = [
           ...ret.analogValues.slice(0, output.port),
-          u8Value.value,
+          u12Value.value,
           ...ret.analogValues.slice(output.port + 1)  
         ] as RobotState.AnalogValues;
         break;
@@ -128,8 +128,8 @@ namespace SensorObject {
         break;
       }
       case Sensor.Output.Type.Analog: {
-        const u8Value = Value.U8.from(value);
-        state.analogValues[output.port] = u8Value.value;
+        const u12Value = Value.U12.from(value);
+        state.analogValues[output.port] = u12Value.value;
         break;
       }
     }


### PR DESCRIPTION
Analog sensors on the wombat scale from 0 to 4095 instead of 0 to 255. This fixes issue #140. Realistic behavior of sensors may need to be added in the future (like plateauing at certain distances for rangefinder).