### PR TITLE
Send initial register values after worker loads

### DIFF
--- a/src/WorkerInstance.ts
+++ b/src/WorkerInstance.ts
@@ -166,6 +166,15 @@ class WorkerInstance {
         }
         break;
       }
+      case 'workerready': {
+        // Once worker is ready for messages, send initial register values so that registers start in sync
+        const initialRegisters: Protocol.Worker.Register[] = this.registers_.map((value, address) => ({ address, value }));
+        this.worker_.postMessage({
+          type: 'setregister',
+          registers: initialRegisters,
+        } as Protocol.Worker.SetRegisterRequest);
+        break;
+      }
     }
   };
   

--- a/src/WorkerProtocol.ts
+++ b/src/WorkerProtocol.ts
@@ -10,7 +10,7 @@ export namespace Protocol {
       code: string;
     }
 
-    export type Request = StartRequest | SetRegisterRequest | ProgramEndedRequest | ProgramOutputRequest | ProgramErrorRequest;
+    export type Request = StartRequest | SetRegisterRequest | ProgramEndedRequest | ProgramOutputRequest | ProgramErrorRequest | WorkerReadyRequest;
 
     export interface StartResponse {
       type: 'start';
@@ -41,6 +41,10 @@ export namespace Protocol {
       type: 'programerror';
       stdoutput: string;
       stderror: string;
+    }
+    
+    export interface WorkerReadyRequest {
+      type: 'workerready';
     }
   }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -60,3 +60,8 @@ ctx.onmessage = (e: MessageEvent) => {
     }
   } 
 };
+
+// Notify main thread that worker is ready for messages
+ctx.postMessage({
+  type: 'workerready',
+} as Protocol.Worker.WorkerReadyRequest);


### PR DESCRIPTION
Fixes #142 and fixes #128 by ensuring that register values are in sync when the user program starts. After the worker has loaded, it sends a new `workerready` message to the main thread. Then the main thread sends a normal `setregister` message with all its register values in it.