### PR TITLE
Update demobot model for better performance

### DIFF
--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -171,7 +171,7 @@ export class Space {
 
   public async loadMeshes(): Promise<void> {
     // Load model into scene
-    const importMeshResult = await Babylon.SceneLoader.ImportMeshAsync("",'static/', 'demobot_v5.glb', this.scene);
+    const importMeshResult = await Babylon.SceneLoader.ImportMeshAsync("",'static/', 'demobot_v6.glb', this.scene);
 
     // TEMP FIX: Scale everything up by 100 to avoid Ammo issues at small scale
     const rootMesh = importMeshResult.meshes.find(mesh => mesh.name === '__root__');


### PR DESCRIPTION
This PR improves #133 by updating the demobot model for better performance. The model now uses instanced meshes for all the duplicate Lego pieces, resulting in fewer draw calls. The model also had a lot of duplicate materials, which are now consolidated into fewer materials.

You can compare the performance in these playgrounds:
- Current model in `master`: https://playground.babylonjs.com/#JUKXQD#1356
- New model in this PR: https://playground.babylonjs.com/#JUKXQD#1478

Based on Tim's testing, I expect this to improve the performance on Chromebooks, but not all the way to 60 FPS, so let's keep #133 open and I'll try to find more optimizations.

Coincidentally the model file size was roughly halved, which should also improve the initial loading time.