### PR TITLE
Adds functionality for adding items anywhere in scene

### DIFF
--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -27,6 +27,8 @@ export class Space {
 
   private ground: Babylon.Mesh;
   private mat: Babylon.Mesh;
+
+  // List for keeping track of current item meshes in scene
   private itemList: string[] = [];
 
   // The position offset of the robot, applied to the user-specified position
@@ -104,7 +106,6 @@ export class Space {
     this.scene.getPhysicsEngine().setSubTimeStep(5);
 
     this.buildFloor();
-    this.createPaperReam();
 
     // (x, z) coordinates of cans around the board
     this.canCoordinates = [[-22, -14.3], [0, -20.6], [15.5, -23.7], [0, -6.9], [-13.7, 6.8], [0, 6.8], [13.5, 6.8], [25.1, 14.8], [0, 34], [-18.8, 45.4], [0, 54.9], [18.7, 45.4]];
@@ -447,6 +448,7 @@ export class Space {
   public createItem(item: { custom?: Item, default?: string }): void {
     const defaultItemList = Dict.toList(Items);
     let newItem: Item;
+    // Detect if importing default item or custom item
     if (item.default !== undefined) {
       const key = Object.keys(Items).indexOf(item.default);
       if (key !== undefined) {
@@ -482,41 +484,6 @@ export class Space {
     const index = this.itemList.indexOf(id);
     this.itemList = this.itemList.splice(index, 1);
     this.scene.getMeshByName(id).dispose();
-  }
-
-  public createCan(canNumber: number): void {
-    const canName = `Can${canNumber}`;
-    const canMaterial = new Babylon.StandardMaterial("can", this.scene);
-    canMaterial.diffuseTexture = new Babylon.Texture('static/Can Texture.png',this.scene);
-    canMaterial.emissiveTexture = canMaterial.diffuseTexture.clone();
-    canMaterial.emissiveColor = new Babylon.Color3(0.1,0.1,0.1);
-    const faceUV: Babylon.Vector4[] = [];
-    faceUV[0] = Babylon.Vector4.Zero();
-    faceUV[1] = new Babylon.Vector4(1, 0, 0, 1);
-    faceUV[2] = Babylon.Vector4.Zero();
-
-    const new_can = Babylon.MeshBuilder.CreateCylinder(canName,{ height:11.15, diameter:6, faceUV: faceUV }, this.scene);
-    new_can.material = canMaterial;
-    new_can.physicsImpostor = new Babylon.PhysicsImpostor(new_can, Babylon.PhysicsImpostor.CylinderImpostor, { mass: 5, friction: 5 }, this.scene);
-    new_can.position = new Babylon.Vector3(this.canCoordinates[canNumber - 1][0], 5, this.canCoordinates[canNumber - 1][1]);
-  }
-
-  public destroyCan(canNumber: number): void {
-    const canName = `Can${canNumber}`;
-    this.scene.getMeshByName(canName).dispose();
-  }
-
-  public createPaperReam(): void {
-    const randID = Math.floor(Math.random() * 16777215).toString(16);
-    const reamName = `Ream${randID}`;
-    const reamMaterial = new Babylon.StandardMaterial("ream", this.scene);
-    reamMaterial.emissiveColor = new Babylon.Color3(0.25,0.25,0.25);
-
-    const new_ream = Babylon.MeshBuilder.CreateBox(reamName,{ height:5.18, width:17.6, depth:22.77 }, this.scene);
-    new_ream.material = reamMaterial;
-    new_ream.physicsImpostor = new Babylon.PhysicsImpostor(new_ream, Babylon.PhysicsImpostor.BoxImpostor, { mass: 50, friction: 5 }, this.scene);
-    new_ream.position = new Babylon.Vector3(14, 1, 43.5);
-    new_ream.rotate(Babylon.Axis.Y, Math.PI / 4);
   }
   
   public updateSensorOptions(isNoiseEnabled: boolean): void {

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -27,7 +27,7 @@ export class Space {
 
   private ground: Babylon.Mesh;
   private mat: Babylon.Mesh;
-  private itemList: string[];
+  private itemList: string[] = [];
 
   // The position offset of the robot, applied to the user-specified position
   private robotOffset: Babylon.Vector3 = new Babylon.Vector3(0, 7, -52);
@@ -463,11 +463,13 @@ export class Space {
       case Item.Type.Can: {
         const can = new Can(this.scene, { item: newItem });
         this.itemList.push(can.id);
+        can.place();
         break;
       }
       case Item.Type.PaperReam: {
         const ream = new PaperReam(this.scene, { item: newItem });
         this.itemList.push(ream.id);
+        ream.place();
         break;
       }
       default: {

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -97,6 +97,7 @@ export class Space {
     this.scene.getPhysicsEngine().setSubTimeStep(5);
 
     this.buildFloor();
+    this.createPaperReam();
 
     // (x, z) coordinates of cans around the board
     this.canCoordinates = [[-22, -14.3], [0, -20.6], [15.5, -23.7], [0, -6.9], [-13.7, 6.8], [0, 6.8], [13.5, 6.8], [25.1, 14.8], [0, 34], [-18.8, 45.4], [0, 54.9], [18.7, 45.4]];
@@ -447,7 +448,7 @@ export class Space {
     faceUV[1] = new Babylon.Vector4(1, 0, 0, 1);
     faceUV[2] = Babylon.Vector4.Zero();
 
-    const new_can = Babylon.MeshBuilder.CreateCylinder(canName,{ height:10, diameter:6, faceUV: faceUV }, this.scene);
+    const new_can = Babylon.MeshBuilder.CreateCylinder(canName,{ height:11.15, diameter:6, faceUV: faceUV }, this.scene);
     new_can.material = canMaterial;
     new_can.physicsImpostor = new Babylon.PhysicsImpostor(new_can, Babylon.PhysicsImpostor.CylinderImpostor, { mass: 5, friction: 5 }, this.scene);
     new_can.position = new Babylon.Vector3(this.canCoordinates[canNumber - 1][0], 5, this.canCoordinates[canNumber - 1][1]);
@@ -456,6 +457,21 @@ export class Space {
   public destroyCan(canNumber: number): void {
     const canName = `Can${canNumber}`;
     this.scene.getMeshByName(canName).dispose();
+  }
+
+  public createPaperReam(): void {
+    const randID = Math.floor(Math.random() * 16777215).toString(16);
+    const reamName = `Ream${randID}`;
+    const reamMaterial = new Babylon.StandardMaterial("ream", this.scene);
+    // reamMaterial.diffuseTexture = new Babylon.Texture('static/Can Texture.png',this.scene);
+    // reamMaterial.emissiveTexture = reamMaterial.diffuseTexture.clone();
+    reamMaterial.emissiveColor = new Babylon.Color3(0,0,0);
+
+    const new_ream = Babylon.MeshBuilder.CreateBox(reamName,{ height:5.18, width:17.6, depth:22.77 }, this.scene);
+    new_ream.material = reamMaterial;
+    new_ream.physicsImpostor = new Babylon.PhysicsImpostor(new_ream, Babylon.PhysicsImpostor.BoxImpostor, { mass: 50, friction: 5 }, this.scene);
+    new_ream.position = new Babylon.Vector3(14, 1, 43.5);
+    new_ream.rotate(Babylon.Axis.Y, Math.PI / 4);
   }
   
   public updateSensorOptions(isNoiseEnabled: boolean): void {

--- a/src/components/SimulatorArea.tsx
+++ b/src/components/SimulatorArea.tsx
@@ -82,7 +82,7 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps> {
     const canName = `Can${canNumber + 1}`;
     isEnabled
       ? this.space.createItem({ default: canName })
-      : this.space.destroyCan(canNumber + 1);
+      : this.space.destroyItem(canName);
   }
 
   render(): React.ReactNode {

--- a/src/components/SimulatorArea.tsx
+++ b/src/components/SimulatorArea.tsx
@@ -79,8 +79,9 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps> {
   };
 
   private setCanEnabled(canNumber: number, isEnabled: boolean) {
+    const canName = `Can${canNumber + 1}`;
     isEnabled
-      ? this.space.createCan(canNumber + 1)
+      ? this.space.createItem({ default: canName })
       : this.space.destroyCan(canNumber + 1);
   }
 

--- a/src/items/Can.ts
+++ b/src/items/Can.ts
@@ -46,9 +46,10 @@ export class Can implements ItemObject {
 
     this.mesh.position = this.config_.item.startPosition;
     this.mesh.rotate(this.config_.item.rotationAxis, this.config_.item.startRotation);
-    // this.config_.list.push(this.config_.item.id);
   }
 
+  // Used to create physics impostor of mesh in scene and make opaque
+  // Can be used after mesh is created so that transparent item can be maniplated around scene before interacting with it
   public place(): void {
     this.mesh.visibility = 1;
     this.mesh.physicsImpostor = new Babylon.PhysicsImpostor(

--- a/src/items/Can.ts
+++ b/src/items/Can.ts
@@ -1,0 +1,64 @@
+import * as Babylon from 'babylonjs';
+import Item from './Item';
+import ItemObject from './ItemObject';
+
+export class Can implements ItemObject {
+  private config_: ItemObject.Config<Item.Can>;
+
+  private mesh: Babylon.AbstractMesh;
+
+  private scene: Babylon.Scene;
+
+  get item(): Item.Can {
+    return this.config_.item;
+  }
+  get id(): string {
+    return this.config_.item.id;
+  }
+
+  constructor(scene: Babylon.Scene, config: ItemObject.Config<Item.Can>) {
+    const item = Item.Can.fill(config.item);
+    this.scene = scene;
+    this.config_ = { ...config, item };
+
+    const canMaterial = new Babylon.StandardMaterial("can", this.scene);
+    canMaterial.diffuseTexture = new Babylon.Texture('static/Can Texture.png',this.scene);
+    canMaterial.emissiveTexture = canMaterial.diffuseTexture.clone();
+    canMaterial.emissiveColor = new Babylon.Color3(0.1,0.1,0.1);
+
+    const faceUV: Babylon.Vector4[] = [];
+    faceUV[0] = Babylon.Vector4.Zero();
+    faceUV[1] = new Babylon.Vector4(1, 0, 0, 1);
+    faceUV[2] = Babylon.Vector4.Zero();
+
+    this.mesh = Babylon.MeshBuilder.CreateCylinder(
+      this.config_.item.id,
+      {
+        height:11.15, 
+        diameter:6, 
+        faceUV: faceUV,
+      }, 
+      this.scene
+    );
+
+    this.mesh.material = canMaterial;
+    this.mesh.visibility = 0.5;
+
+    this.mesh.position = this.config_.item.startPosition;
+    this.mesh.rotate(this.config_.item.rotationAxis, this.config_.item.startRotation);
+    // this.config_.list.push(this.config_.item.id);
+  }
+
+  public place(): void {
+    this.mesh.visibility = 1;
+    this.mesh.physicsImpostor = new Babylon.PhysicsImpostor(
+      this.mesh, 
+      Babylon.PhysicsImpostor.CylinderImpostor, 
+      { 
+        mass: 5, 
+        friction: 5 
+      }, 
+      this.scene
+    );
+  }
+}

--- a/src/items/Item.ts
+++ b/src/items/Item.ts
@@ -16,6 +16,7 @@ namespace Item {
     };
   }
 
+  // Info needed to add any mesh to the scene
   interface Common {
     startPosition: Babylon.Vector3;
     startRotation?: number;
@@ -28,6 +29,7 @@ namespace Item {
     type: Type.Can;
   }
 
+  // IDs are randomized hex if not specified
   export namespace Can {
     export const fill = (can: Can): Can => ({
       startRotation: 0,

--- a/src/items/Item.ts
+++ b/src/items/Item.ts
@@ -1,0 +1,58 @@
+import * as Babylon from 'babylonjs';
+
+namespace Item {
+  export enum Type {
+    Can,
+    PaperReam
+  }
+
+  export namespace Type {
+    export const toString = (type: Type): string => {
+      switch (type) {
+        case Type.Can: return 'Can';
+        case Type.PaperReam: return 'PaperReam';
+        default: return `Unknown (${JSON.stringify(type)})`;
+      }
+    };
+  }
+
+  interface Common {
+    startPosition: Babylon.Vector3;
+    startRotation?: number;
+    rotationAxis?: Babylon.Vector3;
+    transparent?: boolean;
+    id?: string;
+  }
+
+  export interface Can extends Common {
+    type: Type.Can;
+  }
+
+  export namespace Can {
+    export const fill = (can: Can): Can => ({
+      startRotation: 0,
+      rotationAxis: Babylon.Axis.Y,
+      transparent: true,
+      id: `Can ${Math.floor(Math.random() * 16777215).toString(16)}`,
+      ...can
+    });
+  }
+
+  export interface PaperReam extends Common {
+    type: Type.PaperReam;
+  }
+
+  export namespace PaperReam {
+    export const fill = (ream: PaperReam): PaperReam => ({
+      startRotation: 0,
+      rotationAxis: Babylon.Axis.Y,
+      transparent: true,
+      id: `Ream ${Math.floor(Math.random() * 16777215).toString(16)}`,
+      ...ream
+    });
+  }
+}
+
+type Item = Item.Can | Item.PaperReam;
+
+export default Item;

--- a/src/items/ItemObject.ts
+++ b/src/items/ItemObject.ts
@@ -1,0 +1,18 @@
+import Item from './Item';
+
+interface ItemObject {
+  readonly item: Item;
+  place(): void;
+}
+
+namespace ItemObject {
+  export interface Config<T extends Item> {
+    item: T;
+  }
+
+  export interface Constructor<T extends Item> {
+    new(config: Config<T>): ItemObject;
+  }
+}
+
+export default ItemObject;

--- a/src/items/PaperReam.ts
+++ b/src/items/PaperReam.ts
@@ -1,0 +1,57 @@
+import * as Babylon from 'babylonjs';
+import Item from './Item';
+import ItemObject from './ItemObject';
+
+export class PaperReam implements ItemObject {
+  private config_: ItemObject.Config<Item.PaperReam>;
+
+  private mesh: Babylon.AbstractMesh;
+
+  private scene: Babylon.Scene;
+
+  get item(): Item.PaperReam {
+    return this.config_.item;
+  }
+
+  get id(): string {
+    return this.config_.item.id;
+  }
+
+  constructor(scene: Babylon.Scene, config: ItemObject.Config<Item.PaperReam>) {
+    const item = Item.PaperReam.fill(config.item);
+    this.scene = scene;
+    this.config_ = { ...config, item };
+
+    const reamMaterial = new Babylon.StandardMaterial("ream", this.scene);
+    reamMaterial.emissiveColor = new Babylon.Color3(0.25,0.25,0.25);
+
+    this.mesh = Babylon.MeshBuilder.CreateBox(
+      this.config_.item.id,
+      {
+        height:5.18,
+        width:17.6,
+        depth:22.77
+      },
+      this.scene
+    );
+    this.mesh.material = reamMaterial;
+    this.mesh.visibility = 0.5;
+
+    this.mesh.position = this.config_.item.startPosition;
+    this.mesh.rotate(this.config_.item.rotationAxis, this.config_.item.startRotation);
+    // this.config_.list.push(this.config_.item.id);
+  }
+
+  public place(): void {
+    this.mesh.visibility = 1;
+    this.mesh.physicsImpostor = new Babylon.PhysicsImpostor(
+      this.mesh, 
+      Babylon.PhysicsImpostor.BoxImpostor, 
+      { 
+        mass: 50, 
+        friction: 5 
+      }, 
+      this.scene
+    );
+  }
+}

--- a/src/items/PaperReam.ts
+++ b/src/items/PaperReam.ts
@@ -39,9 +39,10 @@ export class PaperReam implements ItemObject {
 
     this.mesh.position = this.config_.item.startPosition;
     this.mesh.rotate(this.config_.item.rotationAxis, this.config_.item.startRotation);
-    // this.config_.list.push(this.config_.item.id);
   }
 
+  // Used to create physics impostor of mesh in scene and make opaque
+  // Can be used after mesh is created so that transparent item can be maniplated around scene before interacting with it
   public place(): void {
     this.mesh.visibility = 1;
     this.mesh.physicsImpostor = new Babylon.PhysicsImpostor(

--- a/src/items/defaultItems.ts
+++ b/src/items/defaultItems.ts
@@ -1,0 +1,85 @@
+import Item from './Item';
+import Dict from '../Dict';
+
+import * as Babylon from 'babylonjs';
+
+export default {
+  'Can1': {
+    type: Item.Type.Can,
+    startPosition: new Babylon.Vector3(-22, 5, -14.3),
+    id: 'Can1',
+  },
+
+  'Can2': {
+    type: Item.Type.Can,
+    startPosition: new Babylon.Vector3(0, 5, -20.6),
+    id: 'Can2',
+  },
+
+  'Can3': {
+    type: Item.Type.Can,
+    startPosition: new Babylon.Vector3(15.5, 5, -23.7),
+    id: 'Can3',
+  },
+
+  'Can4': {
+    type: Item.Type.Can,
+    startPosition: new Babylon.Vector3(0, 5, -6.9),
+    id: 'Can4',
+  },
+
+  'Can5': {
+    type: Item.Type.Can,
+    startPosition: new Babylon.Vector3(-13.7, 5, 6.8),
+    id: 'Can5',
+  },
+
+  'Can6': {
+    type: Item.Type.Can,
+    startPosition: new Babylon.Vector3(0, 5, 6.8),
+    id: 'Can6',
+  },
+
+  'Can7': {
+    type: Item.Type.Can,
+    startPosition: new Babylon.Vector3(13.5, 5, 6.8),
+    id: 'Can7',
+  },
+
+  'Can8': {
+    type: Item.Type.Can,
+    startPosition: new Babylon.Vector3(25.1, 5, 14.8),
+    id: 'Can8',
+  },
+
+  'Can9': {
+    type: Item.Type.Can,
+    startPosition: new Babylon.Vector3(0, 5, 34),
+    id: 'Can9',
+  },
+
+  'Can10': {
+    type: Item.Type.Can,
+    startPosition: new Babylon.Vector3(-18.8, 5, 45.4),
+    id: 'Can10',
+  },
+
+  'Can11': {
+    type: Item.Type.Can,
+    startPosition: new Babylon.Vector3(0, 5, 54.9),
+    id: 'Can11',
+  },
+
+  'Can12': {
+    type: Item.Type.Can,
+    startPosition: new Babylon.Vector3(18.7, 5, 45.4),
+    id: 'Can12',
+  },
+
+  'PaperReam1': {
+    type: Item.Type.PaperReam,
+    startPosition: new Babylon.Vector3(14, 1, 43.5),
+    startRotation: Math.PI / 4,
+    rotationAxis: Babylon.Axis.Y,
+  }
+} as Dict<Item>;

--- a/src/items/index.ts
+++ b/src/items/index.ts
@@ -1,0 +1,41 @@
+// import * as Babylon from 'babylonjs';
+// // import Item from './Item';
+// import { Item } from '.';
+// import ItemObject from './ItemObject';
+// import { Can } from './Can';
+// import Dict from '../Dict';
+// import { default as Items } from './defaultItems';
+
+export { default as Item } from './Item';
+export { default as ItemObject } from './Item';
+export * from './Can';
+export * from './PaperReam';
+export { default as Items } from './defaultItems';
+
+// const defaultItemList = Dict.toList(Items);
+
+// export function instantiate(scene: Babylon.Scene, customItem?: Item, id?: string): ItemObject {
+//   let item: Item;
+//   if (id !== undefined) {
+//     const key = Object.keys(Items).indexOf(id);
+//     if (key !== undefined) {
+//       item = defaultItemList[key][1];
+//       switch (item.type) {
+//         case Item.Type.Can:
+//           return new Can({ scene, item });
+//         case Item.Type.PaperReam:
+//           throw new Error('Working on reams still');
+//       }
+//     } else {
+//       throw new Error('Could not find by id');
+//     }
+//   } else if (customItem !== undefined) {
+//     item = customItem;
+//   } else {
+//     throw new Error('No Item or id was used');
+//   }
+// }
+
+// // export const instantiate = (scene: Babylon.Scene, item: Item): any => {
+
+// // };

--- a/src/items/index.ts
+++ b/src/items/index.ts
@@ -1,41 +1,5 @@
-// import * as Babylon from 'babylonjs';
-// // import Item from './Item';
-// import { Item } from '.';
-// import ItemObject from './ItemObject';
-// import { Can } from './Can';
-// import Dict from '../Dict';
-// import { default as Items } from './defaultItems';
-
 export { default as Item } from './Item';
 export { default as ItemObject } from './Item';
 export * from './Can';
 export * from './PaperReam';
 export { default as Items } from './defaultItems';
-
-// const defaultItemList = Dict.toList(Items);
-
-// export function instantiate(scene: Babylon.Scene, customItem?: Item, id?: string): ItemObject {
-//   let item: Item;
-//   if (id !== undefined) {
-//     const key = Object.keys(Items).indexOf(id);
-//     if (key !== undefined) {
-//       item = defaultItemList[key][1];
-//       switch (item.type) {
-//         case Item.Type.Can:
-//           return new Can({ scene, item });
-//         case Item.Type.PaperReam:
-//           throw new Error('Working on reams still');
-//       }
-//     } else {
-//       throw new Error('Could not find by id');
-//     }
-//   } else if (customItem !== undefined) {
-//     item = customItem;
-//   } else {
-//     throw new Error('No Item or id was used');
-//   }
-// }
-
-// // export const instantiate = (scene: Babylon.Scene, item: Item): any => {
-
-// // };


### PR DESCRIPTION
Functionality added for creating objects anywhere in screen. UI for this will still need to be created. Currently cans and paper reams are supported but more can be added as needed. This should be some of the beginning work on issue #61. 