### PR TITLE
Fixed world widget hanging around when the editor goes fullscreen

### DIFF
--- a/src/components/OverlayLayout.tsx
+++ b/src/components/OverlayLayout.tsx
@@ -183,7 +183,8 @@ class OverlayLayout extends React.PureComponent<Props, State> {
     this.setState({
       editorSize: EDITOR_SIZES[index].type,
       infoSize,
-      consoleSize
+      consoleSize,
+      worldSize
     });
   };
 
@@ -223,7 +224,8 @@ class OverlayLayout extends React.PureComponent<Props, State> {
     this.setState({
       consoleSize: size.type,
       infoSize,
-      editorSize
+      editorSize,
+      worldSize
     });
   };
 


### PR DESCRIPTION
Fixed #179 