### PR TITLE
Disable swap rendering via portal

### DIFF
--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -55,7 +55,6 @@ export class AboutDialog extends React.PureComponent<Props> {
     return (
       <Dialog theme={theme} name='About' onClose={onClose}>
         <Container theme={theme}>
-          {logo}
           <Bold>Copyright <Fa icon='copyright' /> 2021 <Link theme={theme} href="https://kipr.org/" target="_blank">KISS Institute for Practical Robotics</Link> and External Contributors</Bold>
           <br /> <br />
           This software is licensed under the terms of the <Link theme={theme} href="https://www.gnu.org/licenses/gpl-3.0.en.html" target="_blank">GNU General Public License v3</Link>.

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -55,6 +55,7 @@ export class AboutDialog extends React.PureComponent<Props> {
     return (
       <Dialog theme={theme} name='About' onClose={onClose}>
         <Container theme={theme}>
+          {logo}
           <Bold>Copyright <Fa icon='copyright' /> 2021 <Link theme={theme} href="https://kipr.org/" target="_blank">KISS Institute for Practical Robotics</Link> and External Contributors</Bold>
           <br /> <br />
           This software is licensed under the terms of the <Link theme={theme} href="https://www.gnu.org/licenses/gpl-3.0.en.html" target="_blank">GNU General Public License v3</Link>.

--- a/src/components/Portal.tsx
+++ b/src/components/Portal.tsx
@@ -37,7 +37,8 @@ export namespace Portal {
     render() {
       const { props } = this;
       const { sink, children } = props;
-      return ReactDom.createPortal(children, sink ? sink.ref : document.getElementById('swap'));
+      if (!sink) return null;
+      return ReactDom.createPortal(children, sink.ref);
     }
   }
 }


### PR DESCRIPTION
This prevents a second instance of the simulator from hanging around. Should dramatically increase performance.