### PR TITLE
Show version in About dialog

### DIFF
--- a/configs/webpack/common.js
+++ b/configs/webpack/common.js
@@ -1,6 +1,7 @@
 // shared config (dev and prod)
 const { resolve } = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { DefinePlugin } = require('webpack');
 
 module.exports = {
   entry: {
@@ -81,6 +82,9 @@ module.exports = {
   },
   plugins: [
     new HtmlWebpackPlugin({ template: 'index.html.ejs', }),
+    new DefinePlugin({
+      SIMULATOR_VERSION: JSON.stringify(require('../../package.json').version),
+    }),
   ],
   performance: {
     hints: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "1.0.0",
+  "version": "0.9.0",
   "main": "dist/index.js",
   "author": "KISS Institute for Practical Robotics",
   "license": "GPL-3.0-only",

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -72,8 +72,9 @@ export class AboutDialog extends React.PureComponent<Props> {
         <Container theme={theme}>
           <LogoRow>
             {logo}
-            
           </LogoRow>
+          Version {SIMULATOR_VERSION}
+          <br /> <br />
           <Bold>Copyright <Fa icon='copyright' /> 2021 <Link theme={theme} href="https://kipr.org/" target="_blank">KISS Institute for Practical Robotics</Link> and External Contributors</Bold>
           <br /> <br />
           This software is licensed under the terms of the <Link theme={theme} href="https://www.gnu.org/licenses/gpl-3.0.en.html" target="_blank">GNU General Public License v3</Link>.

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,0 +1,2 @@
+// Globals from Webpack DefinePlugin
+declare const SIMULATOR_VERSION: string;


### PR DESCRIPTION
Fixes #191 by showing the Simulator's version in the About dialog. Uses webpack's `DefinePlugin` to inject the version from `package.json` into the bundle.

Also brought the current version down to 0.9.0, since we aren't quite at 1.0.0.