### PR TITLE
Clear editor errors after successful compile

### DIFF
--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -218,7 +218,8 @@ export class Root extends React.Component<Props, State> {
         .then(js => {
           WorkerInstance.start(js);
           this.setState({
-            simulatorState: SimulatorState.RUNNING
+            simulatorState: SimulatorState.RUNNING,
+            messages: [],
           });
         })
         .catch((e: unknown) => {


### PR DESCRIPTION
Fixes #169 by clearing the errors in the editor after a successful compile. The errors will still appear while the user is typing before they re-compile, but we can't fix that without the incremental compilation backend, so that can be a separate lower-priority issue.