### PR TITLE
Add option for realistic sensors + realistic ET implementation

### DIFF
--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -574,8 +574,11 @@ export class Space {
     this.scene.getMeshByName(id).dispose();
   }
   
-  public updateSensorOptions(isNoiseEnabled: boolean): void {
-    for (const sensorObject of this.sensorObjects_) sensorObject.isNoiseEnabled = isNoiseEnabled;
+  public updateSensorOptions(isNoiseEnabled: boolean, isRealisticEnabled: boolean): void {
+    for (const sensorObject of this.sensorObjects_) {
+      sensorObject.isNoiseEnabled = isNoiseEnabled;
+      sensorObject.isRealisticEnabled = isRealisticEnabled;
+    }
   }
 
   private buildFloor() {

--- a/src/components/Info/Info.tsx
+++ b/src/components/Info/Info.tsx
@@ -14,9 +14,11 @@ import { Simulation } from './Simulation';
 export interface InfoProps extends StyleProps, ThemeProps {
   robotState: RobotState;
   sensorNoise: boolean;
+  realisticSensors: boolean;
 
   onRobotStateChange: (robotState: RobotState) => void;
   onSensorNoiseChange: (enabled: boolean) => void;
+  onRealisticSensorsChange: (enabled: boolean) => void;
 }
 
 interface InfoState {
@@ -138,6 +140,10 @@ class Info extends React.PureComponent<Props, State> {
     this.props.onSensorNoiseChange(enabled);
   };
 
+  private onRealisticSensorsChange_ = (enabled: boolean) => {
+    this.props.onRealisticSensorsChange(enabled);
+  };
+
   private onRobotPositionReSetRequested_ = () => {
     this.props.onRobotStateChange({
       ...this.props.robotState,
@@ -165,6 +171,7 @@ class Info extends React.PureComponent<Props, State> {
       theme,
       robotState,
       sensorNoise,
+      realisticSensors,
       onRobotStateChange
     } = props;
     const { collapsed } = state;
@@ -202,11 +209,13 @@ class Info extends React.PureComponent<Props, State> {
               z={Distance.centimeters(robotState.z)}
               theta={Angle.degrees(robotState.theta)}
               sensorNoise={sensorNoise}
+              realisticSensors={realisticSensors}
               onXChange={this.onXChange_}
               onYChange={this.onYChange_}
               onZChange={this.onZChange_}
               onThetaChange={this.onThetaChange_}
               onSensorNoiseChange={this.onSensorNoiseChange_}
+              onRealisticSensorsChange={this.onRealisticSensorsChange_}
               onRobotPositionResetRequested={this.onRobotPositionReSetRequested_}
               theme={theme}
             />

--- a/src/components/Info/Simulation.tsx
+++ b/src/components/Info/Simulation.tsx
@@ -15,12 +15,14 @@ export interface SimulationProps extends ThemeProps, StyleProps {
   z: Distance;
   theta: Angle;
   sensorNoise: boolean;
+  realisticSensors: boolean;
 
   onXChange: (x: Distance) => void;
   onYChange: (y: Distance) => void;
   onZChange: (z: Distance) => void;
   onThetaChange: (theta: Angle) => void;
   onSensorNoiseChange: (enabled: boolean) => void;
+  onRealisticSensorsChange: (enabled: boolean) => void;
   onRobotPositionResetRequested: () => void;
 }
 
@@ -87,13 +89,17 @@ export class Simulation extends React.PureComponent<Props> {
     this.props.onSensorNoiseChange(enabled);
   };
 
+  private onRealisticSensorsChanged_ = (enabled: boolean) => {
+    this.props.onRealisticSensorsChange(enabled);
+  };
+
   private onRobotPositionResetRequested_ = () => {
     this.props.onRobotPositionResetRequested();
   };
 
   render() {
     const { props } = this;
-    const { theme, style, className, x, y, z, theta, sensorNoise } = props;
+    const { theme, style, className, x, y, z, theta, sensorNoise, realisticSensors } = props;
     return (
       <Container style={style} className={className}>
         <StyledButton theme={theme} children={['Reset']} onClick={this.onRobotPositionResetRequested_}></StyledButton>
@@ -104,6 +110,10 @@ export class Simulation extends React.PureComponent<Props> {
         <StyledField theme={theme} name='Sensor Noise' nameWidth={160}>
           <Spacer />
           <Switch value={sensorNoise} onValueChange={this.onSensorNoiseChanged_} theme={theme} />
+        </StyledField>
+        <StyledField theme={theme} name='Realistic Sensors' nameWidth={160}>
+          <Spacer />
+          <Switch value={realisticSensors} onValueChange={this.onRealisticSensorsChanged_} theme={theme} />
         </StyledField>
       </Container>
     );

--- a/src/components/Layout.ts
+++ b/src/components/Layout.ts
@@ -19,6 +19,8 @@ export interface LayoutProps extends StyleProps, ThemeProps {
   onSurfaceChange: (surfaceName: string) => void;
   sensorNoise: boolean;
   onSensorNoiseChange: (enabled: boolean) => void;
+  realisticSensors: boolean;
+  onRealisticSensorsChange: (enabled: boolean) => void;
   onRobotPositionSetRequested: () => void;
 }
 

--- a/src/components/OverlayLayout.tsx
+++ b/src/components/OverlayLayout.tsx
@@ -286,6 +286,8 @@ class OverlayLayout extends React.PureComponent<Props, State> {
       onSurfaceChange,
       sensorNoise,
       onSensorNoiseChange,
+      realisticSensors,
+      onRealisticSensorsChange,
       onRobotPositionSetRequested,
     } = props;
 
@@ -353,6 +355,7 @@ class OverlayLayout extends React.PureComponent<Props, State> {
             itemEnabled={items}
             onRobotStateUpdate={onStateChange}
             isSensorNoiseEnabled={sensorNoise}
+            isRealisticSensorsEnabled={realisticSensors}
             surfaceState={surfaceState}
           />
         </SimulatorAreaContainer>
@@ -389,6 +392,8 @@ class OverlayLayout extends React.PureComponent<Props, State> {
               onRobotStateChange={onStateChange}
               sensorNoise={sensorNoise}
               onSensorNoiseChange={onSensorNoiseChange}
+              realisticSensors={realisticSensors}
+              onRealisticSensorsChange={onRealisticSensorsChange}
               theme={theme}
             />
           </InfoWidget>

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -29,6 +29,7 @@ type ModalType = 'settings' | 'about' | 'none';
 interface RootState {
   shouldSetRobotPosition: boolean,
   isSensorNoiseEnabled: boolean,
+  isRealisticSensorsEnabled: boolean,
   surfaceState: SurfaceState,
   robotState: RobotState;
   items: boolean[];
@@ -76,6 +77,7 @@ export class Root extends React.Component<Props, State> {
       robotState: WorkerInstance.state,
       shouldSetRobotPosition: false,
       isSensorNoiseEnabled: false,
+      isRealisticSensorsEnabled: false,
       surfaceState: SurfaceStatePresets.jbcA,
       items: Array<boolean>(ITEM_KEYS.length).fill(false),
       layout: Layout.Overlay,
@@ -133,6 +135,10 @@ export class Root extends React.Component<Props, State> {
   
   private onToggleSensorNoise_ = (enabled: boolean) => {
     this.setState({ isSensorNoiseEnabled: enabled });
+  };
+
+  private onToggleRealisticSensors_ = (enabled: boolean) => {
+    this.setState({ isRealisticSensorsEnabled: enabled });
   };
 
   private onUpdateSurfaceState_ = (newSurfaceName: string) => {
@@ -312,6 +318,7 @@ export class Root extends React.Component<Props, State> {
       messages,
       shouldSetRobotPosition,
       isSensorNoiseEnabled,
+      isRealisticSensorsEnabled,
       surfaceState
     } = state;
 
@@ -332,6 +339,8 @@ export class Root extends React.Component<Props, State> {
       onSurfaceChange: this.onUpdateSurfaceState_,
       sensorNoise: isSensorNoiseEnabled,
       onSensorNoiseChange: this.onToggleSensorNoise_,
+      realisticSensors: isRealisticSensorsEnabled,
+      onRealisticSensorsChange: this.onToggleRealisticSensors_,
       onRobotPositionSetRequested: this.onRobotPositionSetRequested_
     };
 

--- a/src/components/SideLayout.tsx
+++ b/src/components/SideLayout.tsx
@@ -165,7 +165,7 @@ class SideLayout extends React.PureComponent<Props, State> {
 
   render() {
     const { props } = this;
-    const { style, className, theme, state, onStateChange, items, onCodeChange, code, console, sensorNoise, onSensorNoiseChange, onRobotPositionSetRequested, surfaceState } = props;
+    const { style, className, theme, state, onStateChange, items, onCodeChange, code, console, sensorNoise, onSensorNoiseChange, realisticSensors, onRealisticSensorsChange, onRobotPositionSetRequested, surfaceState } = props;
     const { editorSize, consoleSize, infoSize, index } = this.state;
 
     let content: JSX.Element;
@@ -201,6 +201,8 @@ class SideLayout extends React.PureComponent<Props, State> {
               onRobotStateChange={onStateChange}
               sensorNoise={sensorNoise}
               onSensorNoiseChange={onSensorNoiseChange}
+              realisticSensors={realisticSensors}
+              onRealisticSensorsChange= {onRealisticSensorsChange}
               theme={theme}
             />
           </InfoWidget>
@@ -226,6 +228,7 @@ class SideLayout extends React.PureComponent<Props, State> {
             itemEnabled={items}
             onRobotStateUpdate={onStateChange}
             isSensorNoiseEnabled={sensorNoise}
+            isRealisticSensorsEnabled={realisticSensors}
             surfaceState={surfaceState}
           />
         </SimulatorAreaContainer>

--- a/src/components/SimulatorArea.tsx
+++ b/src/components/SimulatorArea.tsx
@@ -16,6 +16,7 @@ export interface SimulatorAreaProps {
   robotState: RobotState;
   itemEnabled: boolean[];
   isSensorNoiseEnabled: boolean;
+  isRealisticSensorsEnabled: boolean;
   surfaceState: SurfaceState;
 
   onRobotStateUpdate: (robotState: Partial<RobotState>) => void;
@@ -85,7 +86,11 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps> {
     // Check if simulation settings were changed
     if (this.props.isSensorNoiseEnabled !== this.oldIsSensorNoiseEnabled) {
       this.oldIsSensorNoiseEnabled = this.props.isSensorNoiseEnabled;
-      Sim.Space.getInstance().updateSensorOptions(this.props.isSensorNoiseEnabled);
+      Sim.Space.getInstance().updateSensorOptions(this.props.isSensorNoiseEnabled, this.props.isRealisticSensorsEnabled);
+    }
+    
+    if (prevProps.isRealisticSensorsEnabled !== this.props.isRealisticSensorsEnabled) {
+      Sim.Space.getInstance().updateSensorOptions(this.props.isSensorNoiseEnabled, this.props.isRealisticSensorsEnabled);
     }
 
     // Check if board was reset

--- a/src/components/SimulatorArea.tsx
+++ b/src/components/SimulatorArea.tsx
@@ -40,8 +40,6 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps> {
   private containerRef_: HTMLDivElement;
   private canvasRef_: HTMLCanvasElement;
 
-  private oldIsSensorNoiseEnabled: boolean;
-  
   constructor(props: SimulatorAreaProps) {
     super(props);
     this.state = {};
@@ -84,12 +82,7 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps> {
     });
     
     // Check if simulation settings were changed
-    if (this.props.isSensorNoiseEnabled !== this.oldIsSensorNoiseEnabled) {
-      this.oldIsSensorNoiseEnabled = this.props.isSensorNoiseEnabled;
-      Sim.Space.getInstance().updateSensorOptions(this.props.isSensorNoiseEnabled, this.props.isRealisticSensorsEnabled);
-    }
-    
-    if (prevProps.isRealisticSensorsEnabled !== this.props.isRealisticSensorsEnabled) {
+    if (prevProps.isSensorNoiseEnabled !== this.props.isSensorNoiseEnabled || prevProps.isRealisticSensorsEnabled !== this.props.isRealisticSensorsEnabled) {
       Sim.Space.getInstance().updateSensorOptions(this.props.isSensorNoiseEnabled, this.props.isRealisticSensorsEnabled);
     }
 

--- a/src/sensors/Sensor.ts
+++ b/src/sensors/Sensor.ts
@@ -78,7 +78,7 @@ namespace Sensor {
 
   export namespace Et {
     export const fill = (et: Et): Et => ({
-      maxRange: 30,
+      maxRange: 100,
       noiseRadius: 160,
       ...et
     });

--- a/src/sensors/SensorObject.ts
+++ b/src/sensors/SensorObject.ts
@@ -11,6 +11,7 @@ interface SensorObject {
   isVisible: boolean;
   updateVisual(): boolean;
   isNoiseEnabled: boolean;
+  isRealisticEnabled: boolean;
 }
 
 namespace SensorObject {

--- a/src/sensors/TouchSensor.ts
+++ b/src/sensors/TouchSensor.ts
@@ -107,6 +107,14 @@ export class TouchSensor implements SensorObject {
     // Digital sensors aren't noisy
   }
 
+  public get isRealisticEnabled(): boolean {
+    return false;
+  }
+
+  public set isRealisticEnabled(r: boolean) {
+    // Digital sensors don't have realism
+  }
+
   // Determines whether the given mesh is eligible for intersection checking
   // Currently only cans are eligible, but this should be made more flexible
   private static isMeshEligible = (mesh: Babylon.AbstractMesh) => {


### PR DESCRIPTION
Fixes #100:

- Adds a toggle in the Simulation section for "Realistic Sensors" (default is off)
- Implements realistic (nonlinear) output for ET sensors, based on values measured from real ET sensors