### PR TITLE
Separate robot position from robot state + fix reset bug

### DIFF
--- a/src/RobotPosition.ts
+++ b/src/RobotPosition.ts
@@ -1,0 +1,8 @@
+import { Angle, Distance } from "./util";
+
+export interface RobotPosition {
+  x: Distance;
+  y: Distance;
+  z: Distance;
+  theta: Angle;
+}

--- a/src/RobotState.ts
+++ b/src/RobotState.ts
@@ -1,14 +1,6 @@
 
 
 export interface RobotState {
-  // Units: Pixels
-  x: number;
-  y: number;
-  z: number;
-
-  // Units: Radians
-  theta: number;
-
   // Units: Ticks
   motorSpeeds: [number, number, number, number];
   motorPositions: [number, number, number, number];
@@ -20,10 +12,6 @@ export interface RobotState {
 
 export namespace RobotState {
   export const empty: RobotState = {
-    x: 0,
-    y: 0,
-    z: 0,
-    theta: 0,
     motorSpeeds: [0, 0, 0, 0],
     motorPositions: [0, 0, 0, 0],
     servoPositions: [1024, 1024, 1024, 2047],

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -491,7 +491,7 @@ export class Space {
     // Make all sensors visible for now. Eventually the user will be able to control this from the UI
     for (const sensorObject of this.sensorObjects_) sensorObject.isVisible = true;
     
-    this.resetPosition({ x: Distance.centimeters(0), y: Distance.centimeters(0), z: Distance.centimeters(0), theta: Angle.degrees(0) });
+    this.setRobotPosition({ x: Distance.centimeters(0), y: Distance.centimeters(0), z: Distance.centimeters(0), theta: Angle.degrees(0) });
 
     await this.scene.whenReadyAsync();
   }
@@ -503,7 +503,7 @@ export class Space {
   }
 
   // Resets the position/rotation of the robot to the given values (cm and radians)
-  public resetPosition(position: RobotPosition): void {
+  public setRobotPosition(position: RobotPosition): void {
     const rootMeshes = [this.bodyCompoundRootMesh, this.colliderLeftWheelMesh, this.colliderRightWheelMesh, this.armCompoundRootMesh, this.clawCompoundRootMesh];
 
     // Create a transform node, positioned and rotated to match the body root

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -20,6 +20,8 @@ import Dict from './Dict';
 import { SurfaceState } from './SurfaceState';
 
 import { Vector2 } from './math';
+import { RobotPosition } from './RobotPosition';
+import { Angle, Distance } from './util';
 
 export let ACTIVE_SPACE: Space;
 
@@ -489,7 +491,7 @@ export class Space {
     // Make all sensors visible for now. Eventually the user will be able to control this from the UI
     for (const sensorObject of this.sensorObjects_) sensorObject.isVisible = true;
     
-    this.resetPosition();
+    this.resetPosition({ x: Distance.centimeters(0), y: Distance.centimeters(0), z: Distance.centimeters(0), theta: Angle.degrees(0) });
 
     await this.scene.whenReadyAsync();
   }
@@ -500,8 +502,8 @@ export class Space {
     });
   }
 
-  // Resets the position/rotation of the robot to the current robot state
-  public resetPosition(): void {
+  // Resets the position/rotation of the robot to the given values (cm and radians)
+  public resetPosition(position: RobotPosition): void {
     const rootMeshes = [this.bodyCompoundRootMesh, this.colliderLeftWheelMesh, this.colliderRightWheelMesh, this.armCompoundRootMesh, this.clawCompoundRootMesh];
 
     // Create a transform node, positioned and rotated to match the body root
@@ -518,9 +520,10 @@ export class Space {
     }
 
     // Set the position and rotation
-    const { x, y, z, theta } = this.getRobotState();
-    resetTransformNode.setAbsolutePosition(new Babylon.Vector3(x, y, z).addInPlace(this.robotOffset));
-    resetTransformNode.rotationQuaternion = Babylon.Quaternion.RotationAxis(Babylon.Vector3.Up(), Babylon.Tools.ToRadians(theta));
+    // Assuming that position is already in cm/radians. Eventually we'll need to convert depending on the incoming units
+    const { x, y, z, theta } = position;
+    resetTransformNode.setAbsolutePosition(new Babylon.Vector3(x.value, y.value, z.value).addInPlace(this.robotOffset));
+    resetTransformNode.rotationQuaternion = Babylon.Quaternion.RotationAxis(Babylon.Vector3.Up(), Babylon.Tools.ToRadians(theta.value));
 
     // Destroy the transform node
     for (const rootMesh of rootMeshes) {

--- a/src/components/Info/Info.tsx
+++ b/src/components/Info/Info.tsx
@@ -14,10 +14,10 @@ import { RobotPosition } from '../../RobotPosition';
 
 export interface InfoProps extends StyleProps, ThemeProps {
   robotState: RobotState;
-  robotPosition: RobotPosition;
+  robotStartPosition: RobotPosition;
   sensorNoise: boolean;
 
-  onSetRobotPosition: (robotPosition: RobotPosition) => void;
+  onSetRobotStartPosition: (position: RobotPosition) => void;
   onSensorNoiseChange: (enabled: boolean) => void;
 }
 
@@ -125,7 +125,7 @@ class Info extends React.PureComponent<Props, State> {
       theme,
       robotState,
       sensorNoise,
-      robotPosition,
+      robotStartPosition,
     } = props;
     const { collapsed } = state;
 
@@ -157,8 +157,8 @@ class Info extends React.PureComponent<Props, State> {
             collapsed={collapsed['simulation']}
           >
             <Simulation
-              robotPosition={robotPosition}
-              onSetRobotPosition={this.props.onSetRobotPosition}
+              robotStartPosition={robotStartPosition}
+              onSetRobotStartPosition={this.props.onSetRobotStartPosition}
               sensorNoise={sensorNoise}
               onSensorNoiseChange={this.onSensorNoiseChange_}
               theme={theme}

--- a/src/components/Info/Info.tsx
+++ b/src/components/Info/Info.tsx
@@ -7,15 +7,17 @@ import ScrollArea from '../ScrollArea';
 import Section from '../Section';
 import { ThemeProps } from '../theme';
 import SensorWidget from './SensorWidget';
-import { Angle, Distance, StyledText } from '../../util';
+import { StyledText } from '../../util';
 import { Simulation } from './Simulation';
+import { RobotPosition } from '../../RobotPosition';
 
 
 export interface InfoProps extends StyleProps, ThemeProps {
   robotState: RobotState;
+  robotPosition: RobotPosition;
   sensorNoise: boolean;
 
-  onRobotStateChange: (robotState: RobotState) => void;
+  onSetRobotPosition: (robotPosition: RobotPosition) => void;
   onSensorNoiseChange: (enabled: boolean) => void;
 }
 
@@ -102,50 +104,8 @@ class Info extends React.PureComponent<Props, State> {
     };
   }
 
-  private onXChange_ = (x: Distance) => {
-    const { props } = this;
-    const { robotState } = props;
-    const nextRobotState = { ...robotState };
-    nextRobotState.x = x.value;
-    this.props.onRobotStateChange(nextRobotState);
-  };
-
-  private onYChange_ = (y: Distance) => {
-    const { props } = this;
-    const { robotState } = props;
-    const nextRobotState = { ...robotState };
-    nextRobotState.y = y.value;
-    this.props.onRobotStateChange(nextRobotState);
-  };
-
-  private onZChange_ = (z: Distance) => {
-    const { props } = this;
-    const { robotState } = props;
-    const nextRobotState = { ...robotState };
-    nextRobotState.z = z.value;
-    this.props.onRobotStateChange(nextRobotState);
-  };
-
-  private onThetaChange_ = (theta: Angle) => {
-    const { props } = this;
-    const { robotState } = props;
-    const nextRobotState = { ...robotState };
-    nextRobotState.theta = theta.value;
-    this.props.onRobotStateChange(nextRobotState);
-  };
-
   private onSensorNoiseChange_ = (enabled: boolean) => {
     this.props.onSensorNoiseChange(enabled);
-  };
-
-  private onRobotPositionReSetRequested_ = () => {
-    this.props.onRobotStateChange({
-      ...this.props.robotState,
-      x: RobotState.empty.x,
-      y: RobotState.empty.y,
-      z: RobotState.empty.z,
-      theta: RobotState.empty.theta,
-    });
   };
 
   private onCollapsedChange_ = (section: string) => (collapsed: boolean) => {
@@ -165,7 +125,7 @@ class Info extends React.PureComponent<Props, State> {
       theme,
       robotState,
       sensorNoise,
-      onRobotStateChange
+      robotPosition,
     } = props;
     const { collapsed } = state;
 
@@ -197,17 +157,10 @@ class Info extends React.PureComponent<Props, State> {
             collapsed={collapsed['simulation']}
           >
             <Simulation
-              x={Distance.centimeters(robotState.x)}
-              y={Distance.centimeters(robotState.y)}
-              z={Distance.centimeters(robotState.z)}
-              theta={Angle.degrees(robotState.theta)}
+              robotPosition={robotPosition}
+              onSetRobotPosition={this.props.onSetRobotPosition}
               sensorNoise={sensorNoise}
-              onXChange={this.onXChange_}
-              onYChange={this.onYChange_}
-              onZChange={this.onZChange_}
-              onThetaChange={this.onThetaChange_}
               onSensorNoiseChange={this.onSensorNoiseChange_}
-              onRobotPositionResetRequested={this.onRobotPositionReSetRequested_}
               theme={theme}
             />
           </StyledSection>

--- a/src/components/Info/Simulation.tsx
+++ b/src/components/Info/Simulation.tsx
@@ -8,20 +8,14 @@ import Field from '../Field';
 import { Spacer } from '../common';
 import { Switch } from '../Switch';
 import Button from '../Button';
+import { RobotPosition } from '../../RobotPosition';
 
 export interface SimulationProps extends ThemeProps, StyleProps {
-  x: Distance;
-  y: Distance;
-  z: Distance;
-  theta: Angle;
+  robotPosition: RobotPosition;
   sensorNoise: boolean;
 
-  onXChange: (x: Distance) => void;
-  onYChange: (y: Distance) => void;
-  onZChange: (z: Distance) => void;
-  onThetaChange: (theta: Angle) => void;
+  onSetRobotPosition: (robotPosition: RobotPosition) => void;
   onSensorNoiseChange: (enabled: boolean) => void;
-  onRobotPositionResetRequested: () => void;
 }
 
 type Props = SimulationProps;
@@ -68,35 +62,47 @@ const SENSOR_NOISE = StyledText.text({
 
 export class Simulation extends React.PureComponent<Props> {
   private onXChange_ = (x: Value) => {
-    this.props.onXChange(Value.toDistance(x));
+    const xDistance = Value.toDistance(x);
+    if (xDistance.value === this.props.robotPosition.x.value) return;
+
+    this.props.onSetRobotPosition({ ...this.props.robotPosition, x: xDistance });
   };
 
   private onYChange_ = (y: Value) => {
-    this.props.onYChange(Value.toDistance(y));
+    const yDistance = Value.toDistance(y);
+    if (yDistance.value === this.props.robotPosition.y.value) return;
+
+    this.props.onSetRobotPosition({ ...this.props.robotPosition, y: yDistance });
   };
 
   private onZChange_ = (z: Value) => {
-    this.props.onZChange(Value.toDistance(z));
+    const zDistance = Value.toDistance(z);
+    if (zDistance.value === this.props.robotPosition.z.value) return;
+
+    this.props.onSetRobotPosition({ ...this.props.robotPosition, z: zDistance });
   };
 
   private onThetaChange_ = (theta: Value) => {
-    this.props.onThetaChange(Value.toAngle(theta));
+    const angle = Value.toAngle(theta);
+    if (angle.value === this.props.robotPosition.theta.value) return;
+
+    this.props.onSetRobotPosition({ ...this.props.robotPosition, theta: angle });
   };
 
   private onSensorNoiseChanged_ = (enabled: boolean) => {
     this.props.onSensorNoiseChange(enabled);
   };
 
-  private onRobotPositionResetRequested_ = () => {
-    this.props.onRobotPositionResetRequested();
+  private onRobotPositionResetClicked_ = () => {
+    this.props.onSetRobotPosition({ ...this.props.robotPosition });
   };
 
   render() {
     const { props } = this;
-    const { theme, style, className, x, y, z, theta, sensorNoise } = props;
+    const { theme, style, className, sensorNoise, robotPosition: { x, y, z, theta } } = props;
     return (
       <Container style={style} className={className}>
-        <StyledButton theme={theme} children={['Reset']} onClick={this.onRobotPositionResetRequested_}></StyledButton>
+        <StyledButton theme={theme} children={['Reset']} onClick={this.onRobotPositionResetClicked_}></StyledButton>
         <StyledValueEdit value={Value.distance(x)} onValueChange={this.onXChange_} theme={theme} name='X' />
         <StyledValueEdit value={Value.distance(y)} onValueChange={this.onYChange_} theme={theme} name='Y' />
         <StyledValueEdit value={Value.distance(z)} onValueChange={this.onZChange_} theme={theme} name='Z' />

--- a/src/components/Info/Simulation.tsx
+++ b/src/components/Info/Simulation.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { styled } from 'styletron-react';
 import { StyleProps } from '../../style';
-import { Angle, Distance, Value, StyledText } from '../../util';
+import { Value, StyledText } from '../../util';
 import { ThemeProps } from '../theme';
 import ValueEdit from '../ValueEdit';
 import Field from '../Field';
@@ -11,10 +11,10 @@ import Button from '../Button';
 import { RobotPosition } from '../../RobotPosition';
 
 export interface SimulationProps extends ThemeProps, StyleProps {
-  robotPosition: RobotPosition;
+  robotStartPosition: RobotPosition;
   sensorNoise: boolean;
 
-  onSetRobotPosition: (robotPosition: RobotPosition) => void;
+  onSetRobotStartPosition: (position: RobotPosition) => void;
   onSensorNoiseChange: (enabled: boolean) => void;
 }
 
@@ -63,30 +63,30 @@ const SENSOR_NOISE = StyledText.text({
 export class Simulation extends React.PureComponent<Props> {
   private onXChange_ = (x: Value) => {
     const xDistance = Value.toDistance(x);
-    if (xDistance.value === this.props.robotPosition.x.value) return;
+    if (xDistance.value === this.props.robotStartPosition.x.value) return;
 
-    this.props.onSetRobotPosition({ ...this.props.robotPosition, x: xDistance });
+    this.props.onSetRobotStartPosition({ ...this.props.robotStartPosition, x: xDistance });
   };
 
   private onYChange_ = (y: Value) => {
     const yDistance = Value.toDistance(y);
-    if (yDistance.value === this.props.robotPosition.y.value) return;
+    if (yDistance.value === this.props.robotStartPosition.y.value) return;
 
-    this.props.onSetRobotPosition({ ...this.props.robotPosition, y: yDistance });
+    this.props.onSetRobotStartPosition({ ...this.props.robotStartPosition, y: yDistance });
   };
 
   private onZChange_ = (z: Value) => {
     const zDistance = Value.toDistance(z);
-    if (zDistance.value === this.props.robotPosition.z.value) return;
+    if (zDistance.value === this.props.robotStartPosition.z.value) return;
 
-    this.props.onSetRobotPosition({ ...this.props.robotPosition, z: zDistance });
+    this.props.onSetRobotStartPosition({ ...this.props.robotStartPosition, z: zDistance });
   };
 
   private onThetaChange_ = (theta: Value) => {
     const angle = Value.toAngle(theta);
-    if (angle.value === this.props.robotPosition.theta.value) return;
+    if (angle.value === this.props.robotStartPosition.theta.value) return;
 
-    this.props.onSetRobotPosition({ ...this.props.robotPosition, theta: angle });
+    this.props.onSetRobotStartPosition({ ...this.props.robotStartPosition, theta: angle });
   };
 
   private onSensorNoiseChanged_ = (enabled: boolean) => {
@@ -94,12 +94,12 @@ export class Simulation extends React.PureComponent<Props> {
   };
 
   private onRobotPositionResetClicked_ = () => {
-    this.props.onSetRobotPosition({ ...this.props.robotPosition });
+    this.props.onSetRobotStartPosition({ ...this.props.robotStartPosition });
   };
 
   render() {
     const { props } = this;
-    const { theme, style, className, sensorNoise, robotPosition: { x, y, z, theta } } = props;
+    const { theme, style, className, sensorNoise, robotStartPosition: { x, y, z, theta } } = props;
     return (
       <Container style={style} className={className}>
         <StyledButton theme={theme} children={['Reset']} onClick={this.onRobotPositionResetClicked_}></StyledButton>

--- a/src/components/Layout.ts
+++ b/src/components/Layout.ts
@@ -13,8 +13,8 @@ export interface LayoutProps extends StyleProps, ThemeProps {
   onItemChange: (index: string, enabled: boolean) => void;
   state: RobotState;
   onStateChange: (state: RobotState) => void;
-  robotPosition: RobotPosition;
-  onSetRobotPosition: (robotPosition: RobotPosition) => void;
+  robotStartPosition: RobotPosition;
+  onSetRobotStartPosition: (position: RobotPosition) => void;
   console: StyledText;
   messages: Message[];
   onClearConsole: () => void;

--- a/src/components/Layout.ts
+++ b/src/components/Layout.ts
@@ -1,4 +1,5 @@
 import { Message } from "ivygate";
+import { RobotPosition } from "../RobotPosition";
 import { RobotState } from "../RobotState";
 import { StyleProps } from "../style";
 import { SurfaceState } from "../SurfaceState";
@@ -12,6 +13,8 @@ export interface LayoutProps extends StyleProps, ThemeProps {
   onItemChange: (index: string, enabled: boolean) => void;
   state: RobotState;
   onStateChange: (state: RobotState) => void;
+  robotPosition: RobotPosition;
+  onSetRobotPosition: (robotPosition: RobotPosition) => void;
   console: StyledText;
   messages: Message[];
   onClearConsole: () => void;
@@ -19,7 +22,6 @@ export interface LayoutProps extends StyleProps, ThemeProps {
   onSurfaceChange: (surfaceName: string) => void;
   sensorNoise: boolean;
   onSensorNoiseChange: (enabled: boolean) => void;
-  onRobotPositionSetRequested: () => void;
 }
 
 export enum Layout {

--- a/src/components/OverlayLayout.tsx
+++ b/src/components/OverlayLayout.tsx
@@ -275,6 +275,8 @@ class OverlayLayout extends React.PureComponent<Props, State> {
       theme,
       state,
       onStateChange,
+      robotPosition,
+      onSetRobotPosition,
       items,
       code,
       onCodeChange,
@@ -286,7 +288,6 @@ class OverlayLayout extends React.PureComponent<Props, State> {
       onSurfaceChange,
       sensorNoise,
       onSensorNoiseChange,
-      onRobotPositionSetRequested,
     } = props;
 
     const {
@@ -386,7 +387,8 @@ class OverlayLayout extends React.PureComponent<Props, State> {
           >
             <Info
               robotState={state}
-              onRobotStateChange={onStateChange}
+              robotPosition={robotPosition}
+              onSetRobotPosition={onSetRobotPosition}
               sensorNoise={sensorNoise}
               onSensorNoiseChange={onSensorNoiseChange}
               theme={theme}

--- a/src/components/OverlayLayout.tsx
+++ b/src/components/OverlayLayout.tsx
@@ -275,8 +275,8 @@ class OverlayLayout extends React.PureComponent<Props, State> {
       theme,
       state,
       onStateChange,
-      robotPosition,
-      onSetRobotPosition,
+      robotStartPosition,
+      onSetRobotStartPosition,
       items,
       code,
       onCodeChange,
@@ -387,8 +387,8 @@ class OverlayLayout extends React.PureComponent<Props, State> {
           >
             <Info
               robotState={state}
-              robotPosition={robotPosition}
-              onSetRobotPosition={onSetRobotPosition}
+              robotStartPosition={robotStartPosition}
+              onSetRobotStartPosition={onSetRobotStartPosition}
               sensorNoise={sensorNoise}
               onSensorNoiseChange={onSensorNoiseChange}
               theme={theme}

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -32,7 +32,7 @@ interface RootState {
   isSensorNoiseEnabled: boolean,
   surfaceState: SurfaceState,
   robotState: RobotState;
-  robotPosition: RobotPosition;
+  robotStartPosition: RobotPosition;
   items: boolean[];
   layout: Layout;
   code: string;
@@ -76,7 +76,7 @@ export class Root extends React.Component<Props, State> {
 
     this.state = {
       robotState: WorkerInstance.state,
-      robotPosition: {
+      robotStartPosition: {
         x: Distance.centimeters(0),
         y: Distance.centimeters(0),
         z: Distance.centimeters(0),
@@ -130,17 +130,17 @@ export class Root extends React.Component<Props, State> {
     });
   };
 
-  private onSetRobotPosition_ = (robotPosition: RobotPosition) => {
+  private onSetRobotStartPosition_ = (position: RobotPosition) => {
     this.setState({
-      robotPosition: {
-        x: { ...robotPosition.x },
-        y: { ...robotPosition.y },
-        z: { ...robotPosition.z },
-        theta: { ...robotPosition.theta },
+      robotStartPosition: {
+        x: { ...position.x },
+        y: { ...position.y },
+        z: { ...position.z },
+        theta: { ...position.theta },
       }
     });
 
-    Space.getInstance().resetPosition(robotPosition);
+    Space.getInstance().setRobotPosition(position);
   };
 
   private onToggleSensorNoise_ = (enabled: boolean) => {
@@ -316,7 +316,7 @@ export class Root extends React.Component<Props, State> {
     const {
       items,
       robotState,
-      robotPosition,
+      robotStartPosition,
       layout,
       code,
       modal,
@@ -333,8 +333,8 @@ export class Root extends React.Component<Props, State> {
       code,
       items,
       onStateChange: this.onRobotStateUpdate_,
-      robotPosition,
-      onSetRobotPosition: this.onSetRobotPosition_,
+      robotStartPosition,
+      onSetRobotStartPosition: this.onSetRobotStartPosition_,
       theme,
       state: robotState,
       onItemChange: this.onItemChange_,

--- a/src/components/SideLayout.tsx
+++ b/src/components/SideLayout.tsx
@@ -165,7 +165,7 @@ class SideLayout extends React.PureComponent<Props, State> {
 
   render() {
     const { props } = this;
-    const { style, className, theme, state, onStateChange, robotPosition, onSetRobotPosition, items, onCodeChange, code, console, sensorNoise, onSensorNoiseChange, surfaceState } = props;
+    const { style, className, theme, state, onStateChange, robotStartPosition, onSetRobotStartPosition, items, onCodeChange, code, console, sensorNoise, onSensorNoiseChange, surfaceState } = props;
     const { editorSize, consoleSize, infoSize, index } = this.state;
 
     let content: JSX.Element;
@@ -198,8 +198,8 @@ class SideLayout extends React.PureComponent<Props, State> {
           >
             <Info
               robotState={state}
-              robotPosition={robotPosition}
-              onSetRobotPosition={onSetRobotPosition}
+              robotStartPosition={robotStartPosition}
+              onSetRobotStartPosition={onSetRobotStartPosition}
               sensorNoise={sensorNoise}
               onSensorNoiseChange={onSensorNoiseChange}
               theme={theme}

--- a/src/components/SideLayout.tsx
+++ b/src/components/SideLayout.tsx
@@ -165,7 +165,7 @@ class SideLayout extends React.PureComponent<Props, State> {
 
   render() {
     const { props } = this;
-    const { style, className, theme, state, onStateChange, items, onCodeChange, code, console, sensorNoise, onSensorNoiseChange, onRobotPositionSetRequested, surfaceState } = props;
+    const { style, className, theme, state, onStateChange, robotPosition, onSetRobotPosition, items, onCodeChange, code, console, sensorNoise, onSensorNoiseChange, surfaceState } = props;
     const { editorSize, consoleSize, infoSize, index } = this.state;
 
     let content: JSX.Element;
@@ -198,7 +198,8 @@ class SideLayout extends React.PureComponent<Props, State> {
           >
             <Info
               robotState={state}
-              onRobotStateChange={onStateChange}
+              robotPosition={robotPosition}
+              onSetRobotPosition={onSetRobotPosition}
               sensorNoise={sensorNoise}
               onSensorNoiseChange={onSensorNoiseChange}
               theme={theme}

--- a/src/components/SimulatorArea.tsx
+++ b/src/components/SimulatorArea.tsx
@@ -91,18 +91,7 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps> {
     // Check if board was reset
     if (this.props.surfaceState !== prevProps.surfaceState) {
       Sim.Space.getInstance().rebuildFloor(this.props.surfaceState);
-      Sim.Space.getInstance().resetPosition();
     }
-
-    const shouldSetRobotPosition = (
-      prevProps.robotState.x !== this.props.robotState.x ||
-      prevProps.robotState.y !== this.props.robotState.y ||
-      prevProps.robotState.z !== this.props.robotState.z ||
-      prevProps.robotState.theta !== this.props.robotState.theta
-    );
-
-    // Checks if robot position needs to be set
-    if (shouldSetRobotPosition) Sim.Space.getInstance().resetPosition();
   }
 
   private bindContainerRef_ = (ref: HTMLDivElement) => {


### PR DESCRIPTION
- Separates robot position (x, y, z, theta) out of `RobotState`, which should make the position easier to deal with
- [fixes #167] Makes sure that `Sim.setRobotPosition()` gets called even when the UI values don't change
- Clicking "Reset" moves the robot to the last entered position instead of (0, 0, 0, 0). I think this makes more sense because users will likely want to set a single position and reset the robot there repeatedly.