### PR TITLE
Install ivygate as package from GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: simulator
-    - name: Checkout Ivygate
-      uses: actions/checkout@v2
-      with:
-        path: ivygate
-        repository: kipr/ivygate
-    - name: Install Ivygate modules
-      run: yarn install
-      working-directory: ivygate
-    - name: Build Ivygate
-      run: node_modules/.bin/tsc
-      working-directory: ivygate
-    - name: Add Ivygate to Simulator
-      run: yarn add ../ivygate
-      working-directory: simulator
     - name: Install Simulator modules
       run: yarn install
       working-directory: simulator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       with:
         path: simulator
     - name: Install Simulator modules
+      # Specifying an alternative cache folder to work around a race condition issue in yarn,
+      # which seems to occur b/c of how ivygate is referenced from GitHub.
+      # See https://github.com/yarnpkg/yarn/issues/7212
       run: yarn install --cache-folder ./.yarncache
       working-directory: simulator
     - name: Build production bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         path: simulator
     - name: Install Simulator modules
-      run: yarn install
+      run: yarn install --cache-folder ./.yarncache
       working-directory: simulator
     - name: Build production bundle
       run: yarn build

--- a/README.md
+++ b/README.md
@@ -47,34 +47,6 @@ cd emsdk
 ./emsdk activate 2.0.2
 ```
 
-### Install and compile Ivygate
-Clone `ivygate` and compile
-```bash
-git clone https://github.com/kipr/ivygate.git
-cd ivygate
-yarn install
-./node_modules/.bin/tsc
-```
-If you run into this error:
-```bash
-error An unexpected error occurred: "http://localhost:4873..."
-```
-Remove the yarn.lock file and retry yarn install and compile
-
-### Install Dependencies
-
-Navigate to the root directory of this repository, then run:
-```bash
-yarn install
-yarn add ../ivygate
-```
-If you run into this error:
-```bash
-error An unexpected error occurred: "http://localhost:4873..."
-```
-Remove the yarn.lock file and retry yarn install
-
-
 ### Build libwallaby for JavaScript
 
 Clone `libwallaby`:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ cd emsdk
 ./emsdk activate 2.0.2
 ```
 
+### Install Dependencies
+
+Navigate to the root directory of this repository, then run:
+```bash
+yarn install
+```
+
 ### Build libwallaby for JavaScript
 
 Clone `libwallaby`:

--- a/install.sh
+++ b/install.sh
@@ -40,13 +40,6 @@ cd emsdk
 ./emsdk activate 2.0.2
 cd ..
 
-#Install ivygate
-git clone https://github.com/kipr/ivygate.git
-cd ivygate
-yarn install
-./node_modules/.bin/tsc
-cd ..
-
 #Download and install simulator
 echo
 echo Download and install simulator
@@ -55,7 +48,6 @@ echo
 git clone https://github.com/kipr/simulator.git
 cd simulator
 yarn install
-yarn add ../ivygate
 cd ..
 
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "css-loader": "^3.5.3",
     "image-loader": "^0.0.1",
     "image-webpack-loader": "^6.0.0",
-    "ivygate": "../ivygate",
+    "ivygate": "https://github.com/kipr/ivygate#v0.1.0",
     "morgan": "^1.10.0",
     "node": "13.12.0",
     "react": "^17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3615,8 +3615,9 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-ivygate@../ivygate:
-  version "1.0.1"
+"ivygate@https://github.com/kipr/ivygate#v0.1.0":
+  version "0.1.0"
+  resolved "https://github.com/kipr/ivygate#bdec6d33ae16ef1e180bb717c43342a3c031fd0d"
   dependencies:
     monaco "^1.201704190613.0"
     monaco-editor "^0.23.0"


### PR DESCRIPTION
Fixes #172 by installing `ivygate` directly from a tagged version on GitHub. This removes the need to clone/build `ivygate` manually during development, CI, etc.