### PR TITLE
Plot toggle fixes

### DIFF
--- a/src/components/Info/Info.tsx
+++ b/src/components/Info/Info.tsx
@@ -134,31 +134,31 @@ class Info extends React.PureComponent<Props, State> {
 
     const servos = robotState.servoPositions.map((value, i) => (
       <Row key={`servo-pos-${i}`} theme={theme}>
-        <SensorWidget value={value} name={`get_servo_position(${i})`} theme={theme} />
+        <SensorWidget value={value} name={`get_servo_position(${i})`} plotTitle='Servo Position Plot' theme={theme} />
       </Row>
     ));
 
     const motorVelocities = robotState.motorSpeeds.map((value, i) => (
       <Row key={`motor-velocity-${i}`} theme={theme}>
-        <SensorWidget value={value} name={`motor ${i}`} theme={theme} />
+        <SensorWidget value={value} name={`motor ${i}`} plotTitle='Motor Velocity Plot' theme={theme} />
       </Row>
     ));
 
     const motorPositions = robotState.motorPositions.map((value, i) => (
       <Row key={`motor-pos-${i}`} theme={theme}>
-        <SensorWidget value={value} name={`get_motor_position_counter(${i})`} theme={theme} />
+        <SensorWidget value={value} name={`get_motor_position_counter(${i})`} plotTitle='Motor Position Plot' theme={theme} />
       </Row>
     ));
 
     const analogSensors = robotState.analogValues.map((value, i) => (
       <Row key={`analog-${i}`} theme={theme}>
-        <SensorWidget value={value} name={`analog(${i})`} theme={theme} />
+        <SensorWidget value={value} name={`analog(${i})`} plotTitle='Analog Sensor Plot' theme={theme} />
       </Row>
     ));
 
     const digitalSensors = robotState.digitalValues.map((value, i) => (
       <Row key={`digital-${i}`} theme={theme}>
-        <SensorWidget value={value} name={`digital(${i})`} theme={theme} />
+        <SensorWidget value={value} name={`digital(${i})`} plotTitle='Digital Sensor Plot' theme={theme} />
       </Row>
     ));
     

--- a/src/components/Info/SensorWidget.tsx
+++ b/src/components/Info/SensorWidget.tsx
@@ -15,6 +15,7 @@ export interface SensorWidgetProps extends ThemeProps, StyleProps {
   name: string;
   value: number | boolean;
   unit?: string;
+  plotTitle?: string;
 }
 
 interface SensorWidgetState {
@@ -67,6 +68,10 @@ class SensorWidget extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
 
+    if (!props.plotTitle) {
+      props.plotTitle = `Plot`;
+    }
+
     this.state = {
       showGuide: false,
       showActionTooltip: false,
@@ -108,16 +113,24 @@ class SensorWidget extends React.PureComponent<Props, State> {
     });
   };
 
+  private onTogglePlotClick_ = (event: React.MouseEvent<HTMLSpanElement>) => {
+    if (this.state.showPlot) {
+      this.onHidePlotClick_(event);
+    } else {
+      this.onShowPlotClick_(event);
+    }
+  };
+
   render() {
     const { props, state } = this;
-    const { style, className, theme, name, unit, value } = props;
+    const { style, className, theme, name, unit, value, plotTitle } = props;
     const { showGuide, showActionTooltip, showPlot } = state;
 
     let plot: JSX.Element;
 
     const actionItems = [
       StyledText.text({
-        text: `Sensor Plot`,
+        text: plotTitle,
         style: {
           paddingRight: `${theme.itemPadding}px`
         }
@@ -169,7 +182,7 @@ class SensorWidget extends React.PureComponent<Props, State> {
           onMouseEnter={this.onMouseEnter_}
           onMouseLeave={this.onMouseLeave_}
         >
-          <Header theme={theme}>
+          <Header theme={theme} onClick={this.onTogglePlotClick_}>
             <Name>{name}</Name>
             <Spacer />
             <span style={{ userSelect: 'none' }}>{headerValue}{unit}</span>


### PR DESCRIPTION
Giving plot toggles more descriptive names that don't call servos sensors. Also making headers clickable to expand/hide because I don't like small click targets in hovers. 
