### PR TITLE
Make touch sensors detect non-default items + fix duplicate item names

### DIFF
--- a/src/items/Can.ts
+++ b/src/items/Can.ts
@@ -4,6 +4,7 @@ import { ReferenceFrame, Rotation, Vector3 } from '../unit-math';
 import { Item } from '../state';
 import ItemObject from './ItemObject';
 import { Distance, Mass } from '../util';
+import * as uuid from 'uuid';
 
 export class Can implements ItemObject {
   private config_: ItemObject.Config<Item.Can>;
@@ -16,7 +17,7 @@ export class Can implements ItemObject {
     return this.config_.item;
   }
   get id(): string {
-    return this.config_.item.name;
+    return this.mesh.name;
   }
 
   constructor(scene: Babylon.Scene, config: ItemObject.Config<Item.Can>) {
@@ -34,8 +35,11 @@ export class Can implements ItemObject {
     faceUV[1] = new Babylon.Vector4(1, 0, 0, 1);
     faceUV[2] = Babylon.Vector4.Zero();
 
+    // Generate random mesh name to avoid name collisions
+    // TODO: Must be prefixed with "item_" to be detected by sensors. Make this more flexible
+    const meshName = `item_${item.name}_${uuid.v4()}`;
     this.mesh = Babylon.MeshBuilder.CreateCylinder(
-      this.config_.item.name,
+      meshName,
       {
         height: 11.15, 
         diameter: 6, 

--- a/src/items/PaperReam.ts
+++ b/src/items/PaperReam.ts
@@ -4,6 +4,7 @@ import { ReferenceFrame, Rotation, Vector3 } from '../unit-math';
 import { Item } from '../state';
 import { Distance, Mass } from '../util';
 import ItemObject from './ItemObject';
+import * as uuid from 'uuid';
 
 export class PaperReam implements ItemObject {
   private config_: ItemObject.Config<Item.PaperReam>;
@@ -17,7 +18,7 @@ export class PaperReam implements ItemObject {
   }
 
   get id(): string {
-    return this.config_.item.name;
+    return this.mesh.name;
   }
 
   constructor(scene: Babylon.Scene, config: ItemObject.Config<Item.PaperReam>) {
@@ -28,8 +29,11 @@ export class PaperReam implements ItemObject {
     const reamMaterial = new Babylon.StandardMaterial("ream", this.scene);
     reamMaterial.emissiveColor = new Babylon.Color3(0.25,0.25,0.25);
 
+    // Generate random mesh name to avoid name collisions
+    // TODO: Must be prefixed with "item_" to be detected by sensors. Make this more flexible
+    const meshName = `item_${item.name}_${uuid.v4()}`;
     this.mesh = Babylon.MeshBuilder.CreateBox(
-      this.config_.item.name,
+      meshName,
       {
         height:5.18,
         width:17.6,

--- a/src/sensors/TouchSensor.ts
+++ b/src/sensors/TouchSensor.ts
@@ -116,9 +116,9 @@ export class TouchSensor implements SensorObject {
   }
 
   // Determines whether the given mesh is eligible for intersection checking
-  // Currently only cans are eligible, but this should be made more flexible
+  // Currently based on mesh name, but this should be made more flexible
   private static isMeshEligible = (mesh: Babylon.AbstractMesh) => {
-    return mesh.name.startsWith('Can');
+    return mesh.name.startsWith('item');
   };
 }
 


### PR DESCRIPTION
- [fixes #230] Touch sensors detect any meshes that start with `item_`, which includes all default and custom added items
- [fixes #229] Items are given unique mesh names, even if the user-inputted name is duplicated