### PR TITLE
Use libwallaby as a submodule

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 node_modules
 dist
-.github
+
+libwallaby/build
+libwallaby/lib
+
+**/.github

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,5 +98,7 @@ module.exports = {
     "/src/ammo.js",
     // Ignore static files
     "/static",
+    // Ignore libwallaby
+    "/libwallaby",
   ],
 };

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -33,12 +33,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    
-    - name: Checkout libwallaby
-      uses: actions/checkout@v2
       with:
-        repository: 'kipr/libwallaby'
-        path: libwallaby
+        submodules: true
     
     # Get version from package.json
     - name: Get package version

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libwallaby"]
+	path = libwallaby
+	url = https://github.com/kipr/libwallaby

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ yarn watch
 In another terminal, run the server:
 ```bash
 source $PATH_TO_EMSDK/emsdk_env.sh
-LIBWALLABY_ROOT=/path/to/libwallaby node express.js
+node express.js
 ```
 
 ## Configuration
@@ -101,7 +101,7 @@ The server can be configured using environment variables. Variables without defa
 
 | Variable | Description | Default value |
 | -------- | ----------- | ------------- |
-| `LIBWALLABY_ROOT` | Path to the root directory of libwallaby | |
+| `LIBWALLABY_ROOT` | Path to the root directory of libwallaby | `./libwallaby` |
 | `SERVER_PORT` | The port on which to listen for requests | `3000` |
 | `CACHING_STATIC_MAX_AGE` | The max duration (in ms) to allow static assets to be cached | `3600000` (1 hr) |
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ sudo apt-get install cmake
 sudo apt-get install build-essential
 ```
 
+### Clone repository and submodules
+
+Clone this repository and its submodules:
+
+```bash
+git clone --recurse-submodules https://github.com/kipr/Simulator
+```
+
+Or, if you've already cloned the repository without `--recurse-submodules`, you can initialize the submodules separately:
+
+```bash
+git submodule update --init
+```
+
 ### Install Emscripten
 
 See more info here: https://emscripten.org/docs/getting_started/downloads.html
@@ -58,15 +72,11 @@ yarn install
 
 ### Build libwallaby for JavaScript
 
-Clone `libwallaby`:
+Build `libwallaby`:
 ```bash
-git clone https://github.com/kipr/libwallaby.git
 mkdir libwallaby/build
 cd libwallaby/build
-```
 
-Then build:
-```bash
 source $PATH_TO_EMSDK/emsdk_env.sh
 emcmake cmake -Demscripten=ON -Dno_wallaby=ON -Dwith_vision_support=OFF -Dbuild_python=OFF -DBUILD_DOCUMENTATION=OFF ..
 emmake make -j8

--- a/README.md
+++ b/README.md
@@ -110,3 +110,14 @@ The server can be configured using environment variables. Variables without defa
 The project is set up with [ESLint](https://eslint.org/) for JavaScript/TypeScript linting. You can run ESLint manually by running `yarn lint` at the root.
 
 To ease development, we highly recommend enabling ESLint within your editor so you can see issues in real time. If you're using Visual Studio Code, you can use the [VS Code ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint). For other editors, see [available ESLint integrations](https://eslint.org/docs/user-guide/integrations).
+
+# Building image
+
+The repo includes a `Dockerfile` for building a Docker image of the simulator:
+
+```
+# If you don't have jq, you can just use export VERSION=latest
+export VERSION=$(jq -r .version simulator/package.json)
+docker build -t kipr/simulator:$VERSION .
+docker run -ti -p 3000:3000 kipr/simulator:$VERSION
+```

--- a/config.js
+++ b/config.js
@@ -5,7 +5,7 @@ module.exports = {
     return {
       server: {
         port: getEnvVarOrDefault('SERVER_PORT', 3000),
-        libwallabyRoot: getEnvVarOrThrow('LIBWALLABY_ROOT'),
+        libwallabyRoot: getEnvVarOrDefault('LIBWALLABY_ROOT', './libwallaby'),
       },
       caching: {
         staticMaxAge: getEnvVarOrDefault('CACHING_STATIC_MAX_AGE', 60 * 60 * 1000),

--- a/config.js
+++ b/config.js
@@ -20,10 +20,10 @@ function getEnvVarOrDefault(variableName, defaultValue) {
     : defaultValue;
 }
 
-function getEnvVarOrThrow(variableName) {
-  if (process.env[variableName] === undefined) {
-    throw new Error(`Required environment variable is not set: ${variableName}`);
-  }
+// function getEnvVarOrThrow(variableName) {
+//   if (process.env[variableName] === undefined) {
+//     throw new Error(`Required environment variable is not set: ${variableName}`);
+//   }
 
-  return process.env[variableName];
-}
+//   return process.env[variableName];
+// }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/index.js",
   "author": "KISS Institute for Practical Robotics",
   "license": "GPL-3.0-only",


### PR DESCRIPTION
- Adds `libwallaby` as a submodule of this repo
- Set a default value for `LIBWALLABY_ROOT` (since we know where `libwallaby` will be located)
- Update README, workflows, and Docker files to reflect the above changes
- Bump to `v1.0.3`