### PR TITLE
Use commit hash for tagging staging images

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -8,6 +8,7 @@ on:
 env:
   GKE_CLUSTER: kipr
   GKE_ZONE: us-central1-a
+  COMMIT_SHA8: ${GITHUB_SHA::8}
 
 jobs:
   deploy-to-prod:
@@ -22,11 +23,22 @@ jobs:
         service_account_key: ${{ secrets.GCR_SA_KEY }}
         project_id: ${{ secrets.GKE_PROJECT }}
         
-    # Ensure that the Docker image already exists for this version
-    - name: Ensure Docker image exists
+    # Ensure that the Docker image already exists for this commit
+    - name: Ensure Docker image exists for commit
+      run: |-
+        NUM_IMAGES=$(gcloud container images list-tags gcr.io/kipr-321905/kipr/simulator --filter="tags:${COMMIT_SHA8}" --format=json | jq '. | length')
+        if (( NUM_IMAGES <= 0 )); then exit 1; fi
+    
+    # Ensure there isn't already a Docker image for this version tag
+    - name: Ensure Docker image does not exist for tag
       run: |-
         NUM_IMAGES=$(gcloud container images list-tags gcr.io/kipr-321905/kipr/simulator --filter="tags:${GITHUB_REF#refs/tags/v}" --format=json | jq '. | length')
-        if (( NUM_IMAGES <= 0 )); then exit 1; fi
+        if (( NUM_IMAGES > 0 )); then exit 1; fi
+    
+    # Add version tag to Docker image
+    - name: Add version tag to Docker image
+      run: |-
+        gcloud container images add-tag gcr.io/kipr-321905/kipr/simulator:${COMMIT_SHA8} gcr.io/kipr-321905/kipr/simulator:${GITHUB_REF#refs/tags/v}
 
     - name: Checkout deployment repo
       uses: actions/checkout@v2

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -8,7 +8,6 @@ on:
 env:
   GKE_CLUSTER: kipr
   GKE_ZONE: us-central1-a
-  COMMIT_SHA8: ${GITHUB_SHA::8}
 
 jobs:
   deploy-to-prod:
@@ -16,6 +15,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout simulator repo
+      uses: actions/checkout@v2
+      with:
+        path: simulator-repo
+    
+    # Ensure tag matches package.json version
+    - name: Check tag and package version
+      id: check_version
+      run: |-
+        PACKAGE_VERSION=$(jq -r .version package.json)
+        TAG_VERSION=${GITHUB_REF#refs/tags/v}
+        if [[ "$PACKAGE_VERSION" != "$TAG_VERSION" ]]; then exit 1; fi
+        echo "::set-output name=VERSION::${TAG_VERSION}"
+      working-directory: simulator-repo
+
     # Setup gcloud CLI
     - name: Set up gcloud CLI
       uses: google-github-actions/setup-gcloud@v0.2.1
@@ -26,19 +40,19 @@ jobs:
     # Ensure that the Docker image already exists for this commit
     - name: Ensure Docker image exists for commit
       run: |-
-        NUM_IMAGES=$(gcloud container images list-tags gcr.io/kipr-321905/kipr/simulator --filter="tags:${COMMIT_SHA8}" --format=json | jq '. | length')
+        NUM_IMAGES=$(gcloud container images list-tags gcr.io/kipr-321905/kipr/simulator --filter="tags:${GITHUB_SHA::8}" --format=json | jq '. | length')
         if (( NUM_IMAGES <= 0 )); then exit 1; fi
     
     # Ensure there isn't already a Docker image for this version tag
     - name: Ensure Docker image does not exist for tag
       run: |-
-        NUM_IMAGES=$(gcloud container images list-tags gcr.io/kipr-321905/kipr/simulator --filter="tags:${GITHUB_REF#refs/tags/v}" --format=json | jq '. | length')
+        NUM_IMAGES=$(gcloud container images list-tags gcr.io/kipr-321905/kipr/simulator --filter="tags:${{ steps.check_version.outputs.VERSION }}" --format=json | jq '. | length')
         if (( NUM_IMAGES > 0 )); then exit 1; fi
     
     # Add version tag to Docker image
     - name: Add version tag to Docker image
       run: |-
-        gcloud container images add-tag gcr.io/kipr-321905/kipr/simulator:${COMMIT_SHA8} gcr.io/kipr-321905/kipr/simulator:${GITHUB_REF#refs/tags/v}
+        gcloud container images add-tag gcr.io/kipr-321905/kipr/simulator:${GITHUB_SHA::8} gcr.io/kipr-321905/kipr/simulator:${{ steps.check_version.outputs.VERSION }}
 
     - name: Checkout deployment repo
       uses: actions/checkout@v2
@@ -59,5 +73,5 @@ jobs:
         helm upgrade \
           --install \
           --namespace prod \
-          --set imageVersion=${GITHUB_REF#refs/tags/v} \
+          --set imageVersion=${{ steps.check_version.outputs.VERSION }} \
           simulator ./simulator

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -27,12 +27,13 @@ jobs:
   build-publish:
     name: Build and publish
     runs-on: ubuntu-latest
-    # outputs:
-    #   image_version: ${{ steps.package_version.outputs.PACKAGE_VERSION }}
+    outputs:
+      image_version: ${{ steps.image_tag.outputs.IMAGE_TAG }}
 
     steps:
-    - name: Set image tag env var
-      run: echo IMAGE_TAG=${GITHUB_SHA::8} >> $GITHUB_ENV
+    - name: Set image tag output
+      id: image_tag
+      run: echo "::set-output name=IMAGE_TAG::${GITHUB_SHA::8}"
 
     - name: Checkout
       uses: actions/checkout@v2
@@ -55,7 +56,7 @@ jobs:
     # Ensure there isn't already a Docker image for this version
     - name: Ensure Docker image does not exist
       run: |-
-        NUM_IMAGES=$(gcloud container images list-tags gcr.io/kipr-321905/kipr/simulator --filter="tags:${IMAGE_TAG}" --format=json | jq '. | length')
+        NUM_IMAGES=$(gcloud container images list-tags gcr.io/kipr-321905/kipr/simulator --filter="tags:${{ steps.image_tag.outputs.IMAGE_TAG }}" --format=json | jq '. | length')
         if (( NUM_IMAGES > 0 )); then exit 1; fi
 
     # Configure Docker to use the gcloud command-line tool as a credential helper for authentication
@@ -67,13 +68,13 @@ jobs:
     - name: Build Docker image
       run: |-
         docker build \
-          --tag "gcr.io/$PROJECT_ID/$IMAGE:${IMAGE_TAG}" \
+          --tag "gcr.io/$PROJECT_ID/$IMAGE:${{ steps.image_tag.outputs.IMAGE_TAG }}" \
           .
 
     # Push the Docker image to Google Container Registry
     - name: Publish Docker image to GCR
       run: |-
-        docker push "gcr.io/$PROJECT_ID/$IMAGE:${IMAGE_TAG}"
+        docker push "gcr.io/$PROJECT_ID/$IMAGE:${{ steps.image_tag.outputs.IMAGE_TAG }}"
   
   deploy-to-staging:
     name: Deploy to staging
@@ -101,5 +102,5 @@ jobs:
           --install \
           --namespace prerelease \
           --values ./simulator/values.prerelease.yaml \
-          --set imageVersion=${IMAGE_TAG} \
+          --set imageVersion=${{ needs.build-publish.outputs.image_version }} \
           simulator-prerelease ./simulator

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -15,7 +15,7 @@ name: Build and deploy to staging
 on:
   push:
     branches:
-      - hash-for-staging-images
+      - master
 
 env:
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Set image tag env var
-      run: echo ::set-env name=IMAGE_TAG::${GITHUB_SHA::8}
+      run: echo IMAGE_TAG=${GITHUB_SHA::8} >> $GITHUB_ENV
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -15,20 +15,21 @@ name: Build and deploy to staging
 on:
   push:
     branches:
-      - master
+      - hash-for-staging-images
 
 env:
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
   GKE_CLUSTER: kipr
   GKE_ZONE: us-central1-a
   IMAGE: kipr/simulator
+  COMMIT_SHA8: ${GITHUB_SHA::8}
 
 jobs:
   build-publish:
     name: Build and publish
     runs-on: ubuntu-latest
-    outputs:
-      image_version: ${{ steps.package_version.outputs.PACKAGE_VERSION }}
+    # outputs:
+    #   image_version: ${{ steps.package_version.outputs.PACKAGE_VERSION }}
 
     steps:
     - name: Checkout
@@ -36,11 +37,11 @@ jobs:
       with:
         submodules: true
     
-    # Get version from package.json
-    - name: Get package version
-      id: package_version
-      run: |-
-        echo "::set-output name=PACKAGE_VERSION::$(jq -r .version package.json)"
+    # # Get version from package.json
+    # - name: Get package version
+    #   id: package_version
+    #   run: |-
+    #     echo "::set-output name=PACKAGE_VERSION::$(jq -r .version package.json)"
 
     # Setup gcloud CLI
     - name: Set up gcloud CLI
@@ -51,9 +52,8 @@ jobs:
     
     # Ensure there isn't already a Docker image for this version
     - name: Ensure Docker image does not exist
-      id: get_existing_images
       run: |-
-        NUM_IMAGES=$(gcloud container images list-tags gcr.io/kipr-321905/kipr/simulator --filter="tags:${{ steps.package_version.outputs.PACKAGE_VERSION }}" --format=json | jq '. | length')
+        NUM_IMAGES=$(gcloud container images list-tags gcr.io/kipr-321905/kipr/simulator --filter="tags:${COMMIT_SHA8}" --format=json | jq '. | length')
         if (( NUM_IMAGES > 0 )); then exit 1; fi
 
     # Configure Docker to use the gcloud command-line tool as a credential helper for authentication
@@ -65,13 +65,13 @@ jobs:
     - name: Build Docker image
       run: |-
         docker build \
-          --tag "gcr.io/$PROJECT_ID/$IMAGE:${{ steps.package_version.outputs.PACKAGE_VERSION }}" \
+          --tag "gcr.io/$PROJECT_ID/$IMAGE:${COMMIT_SHA8}" \
           .
 
     # Push the Docker image to Google Container Registry
     - name: Publish Docker image to GCR
       run: |-
-        docker push "gcr.io/$PROJECT_ID/$IMAGE:${{ steps.package_version.outputs.PACKAGE_VERSION }}"
+        docker push "gcr.io/$PROJECT_ID/$IMAGE:${COMMIT_SHA8}"
   
   deploy-to-staging:
     name: Deploy to staging
@@ -99,5 +99,5 @@ jobs:
           --install \
           --namespace prerelease \
           --values ./simulator/values.prerelease.yaml \
-          --set imageVersion=${{ needs.build-publish.outputs.image_version }} \
+          --set imageVersion=${COMMIT_SHA8} \
           simulator-prerelease ./simulator

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -31,20 +31,16 @@ jobs:
       image_version: ${{ steps.image_tag.outputs.IMAGE_TAG }}
 
     steps:
-    - name: Set image tag output
-      id: image_tag
-      run: echo "::set-output name=IMAGE_TAG::${GITHUB_SHA::8}"
-
     - name: Checkout
       uses: actions/checkout@v2
       with:
         submodules: true
     
-    # # Get version from package.json
-    # - name: Get package version
-    #   id: package_version
-    #   run: |-
-    #     echo "::set-output name=PACKAGE_VERSION::$(jq -r .version package.json)"
+    # Calculate image tag name from commit hash
+    - name: Set image tag output
+      id: image_tag
+      run: |-
+        echo "::set-output name=IMAGE_TAG::${GITHUB_SHA::8}"
 
     # Setup gcloud CLI
     - name: Set up gcloud CLI

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -22,7 +22,6 @@ env:
   GKE_CLUSTER: kipr
   GKE_ZONE: us-central1-a
   IMAGE: kipr/simulator
-  COMMIT_SHA8: ${GITHUB_SHA::8}
 
 jobs:
   build-publish:
@@ -32,6 +31,9 @@ jobs:
     #   image_version: ${{ steps.package_version.outputs.PACKAGE_VERSION }}
 
     steps:
+    - name: Set image tag env var
+      run: echo ::set-env name=IMAGE_TAG::${GITHUB_SHA::8}
+
     - name: Checkout
       uses: actions/checkout@v2
       with:
@@ -53,7 +55,7 @@ jobs:
     # Ensure there isn't already a Docker image for this version
     - name: Ensure Docker image does not exist
       run: |-
-        NUM_IMAGES=$(gcloud container images list-tags gcr.io/kipr-321905/kipr/simulator --filter="tags:${COMMIT_SHA8}" --format=json | jq '. | length')
+        NUM_IMAGES=$(gcloud container images list-tags gcr.io/kipr-321905/kipr/simulator --filter="tags:${IMAGE_TAG}" --format=json | jq '. | length')
         if (( NUM_IMAGES > 0 )); then exit 1; fi
 
     # Configure Docker to use the gcloud command-line tool as a credential helper for authentication
@@ -65,13 +67,13 @@ jobs:
     - name: Build Docker image
       run: |-
         docker build \
-          --tag "gcr.io/$PROJECT_ID/$IMAGE:${COMMIT_SHA8}" \
+          --tag "gcr.io/$PROJECT_ID/$IMAGE:${IMAGE_TAG}" \
           .
 
     # Push the Docker image to Google Container Registry
     - name: Publish Docker image to GCR
       run: |-
-        docker push "gcr.io/$PROJECT_ID/$IMAGE:${COMMIT_SHA8}"
+        docker push "gcr.io/$PROJECT_ID/$IMAGE:${IMAGE_TAG}"
   
   deploy-to-staging:
     name: Deploy to staging
@@ -99,5 +101,5 @@ jobs:
           --install \
           --namespace prerelease \
           --values ./simulator/values.prerelease.yaml \
-          --set imageVersion=${COMMIT_SHA8} \
+          --set imageVersion=${IMAGE_TAG} \
           simulator-prerelease ./simulator

--- a/configs/webpack/common.js
+++ b/configs/webpack/common.js
@@ -3,6 +3,8 @@ const { resolve } = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { DefinePlugin } = require('webpack');
 
+const commitHash = require('child_process').execSync('git rev-parse --short=8 HEAD').toString().trim();
+
 module.exports = {
   entry: {
     app: './index.tsx',
@@ -84,6 +86,7 @@ module.exports = {
     new HtmlWebpackPlugin({ template: 'index.html.ejs', }),
     new DefinePlugin({
       SIMULATOR_VERSION: JSON.stringify(require('../../package.json').version),
+      SIMULATOR_GIT_HASH: JSON.stringify(commitHash),
     }),
   ],
   performance: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/index.js",
   "author": "KISS Institute for Practical Robotics",
   "license": "GPL-3.0-only",

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -71,7 +71,7 @@ export class AboutDialog extends React.PureComponent<Props> {
           <LogoRow>
             {logo}
           </LogoRow>
-          Version {SIMULATOR_VERSION}
+          Version {SIMULATOR_VERSION} ({SIMULATOR_GIT_HASH})
           <br /> <br />
           <Bold>Copyright <Fa icon='copyright' /> 2021 <Link theme={theme} href="https://kipr.org/" target="_blank">KISS Institute for Practical Robotics</Link> and External Contributors</Bold>
           <br /> <br />

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,2 +1,3 @@
 // Globals from Webpack DefinePlugin
 declare const SIMULATOR_VERSION: string;
+declare const SIMULATOR_GIT_HASH: string;


### PR DESCRIPTION
- In the staging workflow, when creating the image, tag it with the commit hash (instead of the `package.json` version)
- In the prod workflow, when deploying the image, re-tag the existing image with the version
- In the About dialog, show the short commit hash next to the version. Since we may have multiple images with the same version number, this is useful for verifying which image you're using
- Bump to `v1.0.4` to avoid any conflicts with the existing `v1.0.3` image