### PR TITLE
Fix workflow status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Simulator
-[![CI Bot](https://github.com/kipr/simulator/actions/workflows/ci.yml/badge.svg)](https://github.com/kipr/simulator/actions/workflows/ci.yml)
+
+![CD staging status](https://github.com/kipr/simulator/actions/workflows/cd-staging.yml/badge.svg)
+
+![CD prod status](https://github.com/kipr/simulator/actions/workflows/cd-prod.yml/badge.svg)
 
 A Robotics Simulator built in typescript.
 Simulates a botball/JBC style demobot with a built in IDE.


### PR DESCRIPTION
The current status badge in the README is tied to the CI workflow, which only runs on PRs, not on `master`. This PR replaces that badge with two badges that are tied to the staging/prod deployments.