### PR TITLE
Make toggle on/off states easier to distinguish

### DIFF
--- a/src/components/ComboBox.tsx
+++ b/src/components/ComboBox.tsx
@@ -7,7 +7,7 @@ import { AnyText } from "../util";
 import { Color } from "../util/Color";
 import { Fa } from "./Fa";
 import { Text } from "./Text";
-import { DARK, ThemeProps } from "./theme";
+import { ThemeProps } from "./theme";
 
 const Container = styled('div', (props: ThemeProps & { $focus?: boolean; $minimal?: boolean; }) => ({
   width: !props.$minimal ? '100%' : undefined,

--- a/src/components/theme.ts
+++ b/src/components/theme.ts
@@ -87,7 +87,7 @@ export const LIGHT: Theme = {
   switch: {
     on: {
       primary: 'rgb(0, 0, 0)',
-      secondary: 'rgba(0, 0, 0, 0.2)'
+      secondary: 'rgb(72, 139, 73)'
     },
     off: {
       primary: 'rgb(127, 127, 127)',
@@ -108,7 +108,7 @@ export const DARK: Theme = {
   switch: {
     on: {
       primary: 'rgb(255, 255, 255)',
-      secondary: 'rgba(255, 255, 255, 0.2)'
+      secondary: 'rgb(72, 139, 73)'
     },
     off: {
       primary: 'rgb(127, 127, 127)',


### PR DESCRIPTION
Fixes #267 by making the background of toggles green when they're toggled on.

![SimulatorToggle](https://user-images.githubusercontent.com/126523/130305834-0da24afc-4d31-41d1-b54a-9a992a36d4bf.gif)
