### PR TITLE
Improve touch support

### DIFF
--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -263,6 +263,7 @@ export class Space {
     this.engine = new Babylon.Engine(this.workingCanvas, true, { preserveDrawingBuffer: true, stencil: true });
     this.scene = new Babylon.Scene(this.engine);
     this.camera = new Babylon.ArcRotateCamera("botcam",10,10,10, new Babylon.Vector3(50,50,50), this.scene);
+    this.camera.panningSensibility = 100;
 
     this.currentEngineView = null;
 

--- a/src/components/SimulatorArea.tsx
+++ b/src/components/SimulatorArea.tsx
@@ -29,7 +29,8 @@ const Canvas = styled('canvas', {
   position: 'absolute',
   ':focus': {
     outline: 'none'
-  }
+  },
+  touchAction: 'none',
 });
 
 export class SimulatorArea extends React.Component<SimulatorAreaProps> {


### PR DESCRIPTION
Related to #262 - hopefully this makes the simulator usable on iPad and similarly-sized tablets.

- Improve touch support in the simulator area. You can drag one finger to rotate, drag two fingers to pan, and pinch two fingers to zoom.
- Improve touch support in the UI scroll areas. You can swipe one finger to scroll as you'd expect on a touchscreen.
- Increase panning sensitivity so you don't have to drag as far to pan a reasonable amount. This should help panning with a mouse too.