### PR TITLE
Fix `cmpc` issue for port 3

### DIFF
--- a/src/WorkerInstance.ts
+++ b/src/WorkerInstance.ts
@@ -134,7 +134,7 @@ class WorkerInstance {
           this.registers_[register.address] = register.value;
 
           // Set "dirty" flag for motor position registers
-          if (Registers.REG_RW_MOT_0_B3 <= register.address && register.address <= Registers.REG_RW_MOT_3_B3) {
+          if (Registers.REG_RW_MOT_0_B3 <= register.address && register.address <= Registers.REG_RW_MOT_3_B0) {
             this.didMotorPositionRegistersChange = true;
           }
         }


### PR DESCRIPTION
Fixes #282 where register changes for port 3's motor position didn't take effect when calling `cmpc(3)`.