### PR TITLE
Some physics fixes for scene-description

### DIFF
--- a/src/SceneBinding.ts
+++ b/src/SceneBinding.ts
@@ -171,7 +171,7 @@ class SceneBinding {
       SceneBinding.apply_(ret, m => {
         m.physicsImpostor = new Babylon.PhysicsImpostor(m, type, {
           mass: node.physics.mass ? Mass.toGramsValue(node.physics.mass) : 0,
-          restitution: node.physics.restitution ?? 1,
+          restitution: node.physics.restitution ?? 0.5,
           friction: node.physics.friction ?? 5,
         });
       });
@@ -337,7 +337,7 @@ class SceneBinding {
         m.parent = null;
         m.physicsImpostor = new Babylon.PhysicsImpostor(m, type, {
           mass: nextPhysics.mass ? Mass.toGramsValue(nextPhysics.mass) : 0,
-          restitution: nextPhysics.restitution ?? 1,
+          restitution: nextPhysics.restitution ?? 0.5,
           friction: nextPhysics.friction ?? 5,
         });
         m.parent = mParent;
@@ -531,6 +531,7 @@ class SceneBinding {
               m, gizmoImposter.type,
               { 
                 mass: gizmoImposter.mass, 
+                restitution: gizmoImposter.restitution,
                 friction: gizmoImposter.friction 
               }
             );

--- a/src/SceneBinding.ts
+++ b/src/SceneBinding.ts
@@ -584,7 +584,7 @@ class SceneBinding {
     }
 
     if (patch.gravity.type === Patch.Type.OuterChange) {
-      this.bScene_.gravity = Vector3.toBabylon(patch.gravity.next, 'centimeters');
+      this.bScene_.getPhysicsEngine().setGravity(Vector3.toBabylon(patch.gravity.next, 'centimeters'));
     }
 
     if (patch.robot.type === Patch.Type.InnerChange) {

--- a/src/SceneBinding.ts
+++ b/src/SceneBinding.ts
@@ -161,7 +161,6 @@ class SceneBinding {
     const parent = this.findBNode_(node.parentId, true);
 
     const ret = await this.buildGeometry_(node.name, nextScene.geometry[node.geometryId]);
-    ret.setParent(parent);
 
     if (!node.visible) {
       SceneBinding.apply_(ret, m => m.isVisible = false);
@@ -170,7 +169,6 @@ class SceneBinding {
     if (node.physics) {
       const type = IMPOSTER_TYPE_MAPPINGS[node.physics.type];
       SceneBinding.apply_(ret, m => {
-        // m.setParent(null);
         m.physicsImpostor = new Babylon.PhysicsImpostor(m, type, {
           mass: node.physics.mass ? Mass.toGramsValue(node.physics.mass) : 0,
           restitution: node.physics.restitution ?? 1,
@@ -178,6 +176,8 @@ class SceneBinding {
         });
       });
     }
+
+    ret.setParent(parent);
 
     return ret;
   };
@@ -333,12 +333,14 @@ class SceneBinding {
       const nextPhysics = node.inner.physics.next;
       const type = IMPOSTER_TYPE_MAPPINGS[node.inner.physics.next.type];
       SceneBinding.apply_(bNode, m => {
-        // m.setParent(null);
+        const mParent = m.parent;
+        m.parent = null;
         m.physicsImpostor = new Babylon.PhysicsImpostor(m, type, {
           mass: nextPhysics.mass ? Mass.toGramsValue(nextPhysics.mass) : 0,
           restitution: nextPhysics.restitution ?? 1,
           friction: nextPhysics.friction ?? 5,
         });
+        m.parent = mParent;
       });
     }
 
@@ -523,6 +525,8 @@ class SceneBinding {
 
             if (!gizmoImposter) return;
 
+            const mParent = m.parent;
+            m.parent = null;
             m.physicsImpostor = new Babylon.PhysicsImpostor(
               m, gizmoImposter.type,
               { 
@@ -530,6 +534,7 @@ class SceneBinding {
                 friction: gizmoImposter.friction 
               }
             );
+            m.parent = mParent;
           });
         }
         this.gizmoManager_.attachToNode(null);

--- a/src/state/reducer/scene.ts
+++ b/src/state/reducer/scene.ts
@@ -289,7 +289,7 @@ export const TEST_SCENE: Scene = {
   }),
   gravity: {
     x: Distance.meters(0),
-    y: Distance.meters(-9.8 * 50),
+    y: Distance.meters(-9.8 / 2),
     z: Distance.meters(0),
   }
 };


### PR DESCRIPTION
(to be merged into `scene-description` branch, not `master`)

- Unparent meshes before creating physics impostors
- Fix setting scene gravity
- Lower default restitution