### PR TITLE
Show compile warnings even if compile succeeds

### DIFF
--- a/express.js
+++ b/express.js
@@ -71,7 +71,7 @@ app.post('/compile', (req, res) => {
 
     exec(`emcc -s WASM=0 -s INVOKE_RUN=0 -s ASYNCIFY -s EXIT_RUNTIME=1 -s "EXPORTED_FUNCTIONS=['_main', '_simMainWrapper']" -I${config.server.libwallabyRoot}/include -L${config.server.libwallabyRoot}/lib -lkipr -o ${path}.js ${path}`, (err, stdout, stderr) => {
       if (err) {
-        return res.status(400).json({
+        return res.status(200).json({
           stdout,
           stderr
         });
@@ -96,8 +96,11 @@ app.post('/compile', (req, res) => {
                 error: `Failed to delete ${path}`
               });
             }
-            res.set('Content-Type', 'application/javascript');
-            res.status(200).send(data);
+            res.status(200).json({
+              result: data.toString(),
+              stdout,
+              stderr,
+            });
           });
         });
       });

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,12 +1,13 @@
-export default (code: string): Promise<string> => {
+export default (code: string): Promise<CompileResult> => {
 
-  return new Promise<string>((resolve, reject) => {
+  return new Promise<CompileResult>((resolve, reject) => {
     const req = new XMLHttpRequest();
     req.onload = () => {
       if (req.status !== 200) {
         reject(JSON.parse(req.responseText));
+        return;
       }
-      resolve(req.responseText);
+      resolve(JSON.parse(req.responseText) as CompileResult);
     };
 
     req.onerror = (err) => {
@@ -24,7 +25,8 @@ export default (code: string): Promise<string> => {
   
 };
 
-export interface CompileError {
+export interface CompileResult {
+  result?: string;
   stdout: string;
   stderr: string;
 }

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -18,11 +18,11 @@ import { SettingsDialog } from './SettingsDialog';
 import { AboutDialog } from './AboutDialog';
 import { FeedbackDialog } from './Feedback';
 import sendFeedback from './Feedback/SendFeedback';
-import compile, { CompileError } from '../compile';
+import compile from '../compile';
 import { SimulatorState } from './SimulatorState';
 import { Angle, Distance, StyledText } from '../util';
 import { Message } from 'ivygate';
-import parseMessages, { hasErrors, sort, toStyledText } from '../util/parse-messages';
+import parseMessages, { hasErrors, hasWarnings, sort, toStyledText } from '../util/parse-messages';
 
 import { Space } from '../Sim';
 import { RobotPosition } from '../RobotPosition';
@@ -262,55 +262,11 @@ export class Root extends React.Component<Props, State> {
       console: nextConsole
     }, () => {
       compile(code)
-        .then(js => {
-          WorkerInstance.start(js);
-          
-          nextConsole = StyledText.extend(nextConsole, StyledText.text({
-            text: `Compilation succeeded!\n`,
-            style: STDOUT_STYLE(this.state.theme)
-          }));
+        .then(compileResult => {
+          const messages = sort(parseMessages(compileResult.stderr));
+          const compileSucceeded = compileResult.result && compileResult.result.length > 0;
 
-          this.setState({
-            simulatorState: SimulatorState.RUNNING,
-            messages: [],
-            console: nextConsole
-          });
-        })
-        .catch((e: unknown) => {
-          /* let nextConsole = console;
-          if (typeof e.stderr === 'string' && e.stderr.length > 0) {
-            nextConsole = StyledText.extend(console, StyledText.text({
-              text: e.stderr,
-              style: STDERR_STYLE(theme)
-            }));
-          }
-          if (typeof e.stdout === 'string' && e.stdout.length > 0) {
-            nextConsole = StyledText.extend(console, StyledText.text({
-              text: e.stdout,
-              style: STDOUT_STYLE(theme)
-            }));
-          }*/
-
-          // TODO: handle cases where e is not a CompileError
-          const compileError = e as CompileError;
-          const messages = sort(parseMessages(compileError.stderr));
-  
-          if (hasErrors(messages) || messages.length === 0) {
-            nextConsole = StyledText.extend(nextConsole, StyledText.text({
-              text: `Compilation failed.\n`,
-              style: STDERR_STYLE(this.state.theme)
-            }));
-          }
-
-          // If there are no messages some weird underlying error occurred
-          // We print the entire stderr to the console
-          if (messages.length === 0) {
-            nextConsole = StyledText.extend(nextConsole, StyledText.text({
-              text: compileError.stderr,
-              style: STDERR_STYLE(this.state.theme)
-            }));
-          }
-  
+          // Show all errors/warnings in console
           for (const message of messages) {
             nextConsole = StyledText.extend(nextConsole, toStyledText(message, {
               onClick: message.ranges.length > 0
@@ -318,11 +274,49 @@ export class Root extends React.Component<Props, State> {
                 : undefined
             }));
           }
-  
-  
+
+          if (compileSucceeded) {
+            // Show success in console and start running the program
+            const haveWarnings = hasWarnings(messages);
+            nextConsole = StyledText.extend(nextConsole, StyledText.text({
+              text: `Compilation succeeded${haveWarnings ? ' with warnings' : ''}!\n`,
+              style: STDOUT_STYLE(this.state.theme)
+            }));
+
+            WorkerInstance.start(compileResult.result);
+          } else {
+            if (!hasErrors(messages)) {
+              // Compile failed and there are no error messages; some weird underlying error occurred
+              // We print the entire stderr to the console
+              nextConsole = StyledText.extend(nextConsole, StyledText.text({
+                text: compileResult.stderr + '\n',
+                style: STDERR_STYLE(this.state.theme)
+              }));
+            }
+
+            nextConsole = StyledText.extend(nextConsole, StyledText.text({
+              text: `Compilation failed.\n`,
+              style: STDERR_STYLE(this.state.theme)
+            }));
+          }
+
+          this.setState({
+            simulatorState: compileSucceeded ? SimulatorState.RUNNING : SimulatorState.STOPPED,
+            messages,
+            console: nextConsole
+          });
+        })
+        .catch((e: unknown) => {
+          window.console.error(e);
+
+          nextConsole = StyledText.extend(nextConsole, StyledText.text({
+            text: 'Something went wrong during compilation.\n',
+            style: STDERR_STYLE(this.state.theme)
+          }));
+
           this.setState({
             simulatorState: SimulatorState.STOPPED,
-            messages,
+            messages: [],
             console: nextConsole
           });
         });

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -289,7 +289,7 @@ export class Root extends React.Component<Props, State> {
               // Compile failed and there are no error messages; some weird underlying error occurred
               // We print the entire stderr to the console
               nextConsole = StyledText.extend(nextConsole, StyledText.text({
-                text: compileResult.stderr + '\n',
+                text: `${compileResult.stderr}\n`,
                 style: STDERR_STYLE(this.state.theme)
               }));
             }


### PR DESCRIPTION
Fixes #299 with a few changes:
- Console/editor show both warnings and errors regardless of the compilation result
- If compilation succeeds with warnings, the console shows "Compilation succeeded with warnings" instead of just "Compilation succeeded"
- `/compile` includes `stdout`/`stderr` in the response, even if the program compiled successfully. This is needed so the UI can parse and display warnings
- `/compile` responds `200` (instead of `400`) even if there are compilation errors. So `200` means "the compilation process succeeded" rather than "the program compiled successfully"