### PR TITLE
[scene-description] Some more physics fixes

### DIFF
--- a/src/SceneBinding.ts
+++ b/src/SceneBinding.ts
@@ -130,6 +130,9 @@ class SceneBinding {
         if (res.meshes.length === 1) return res.meshes[0];
         ret = new Babylon.TransformNode(geometry.uri, this.bScene_);
         for (const mesh of res.meshes) {
+          // GLTF importer adds a __root__ mesh (always the first one) that we can ignore 
+          if (mesh === res.meshes[0]) continue;
+
           mesh.setParent(ret);
         }
         break; 

--- a/src/state/reducer/scene.ts
+++ b/src/state/reducer/scene.ts
@@ -246,7 +246,7 @@ export const TEST_SCENE: Scene = {
       },
       visible: true,
       physics: {
-        type: 'mesh',
+        type: 'box',
         restitution: 0,
         friction: 1
       },


### PR DESCRIPTION
(to be merged into `scene-description` branch, not `master`)

- Update physics impostors after scaling changes
- Unparent meshes before creating physics impostors (I think there's a way to avoid all the unparenting/reparenting, but haven't looked yet)
- Ignore the `__root__` mesh that the GLTF importer adds automatically (we create our own `TransformNode` parent anyway)
- For the mat, use a box impostor instead of a mesh impostor