### PR TITLE
[scene-description] Couple more fixes

### DIFF
--- a/src/SceneBinding.ts
+++ b/src/SceneBinding.ts
@@ -352,13 +352,14 @@ class SceneBinding {
       const type = IMPOSTER_TYPE_MAPPINGS[node.inner.physics.next.type];
       SceneBinding.apply_(bNode, m => {
         const mParent = m.parent;
-        m.parent = null;
+        m.setParent(null);
+        if (m.physicsImpostor) m.physicsImpostor.dispose();
         m.physicsImpostor = new Babylon.PhysicsImpostor(m, type, {
           mass: nextPhysics.mass ? Mass.toGramsValue(nextPhysics.mass) : 0,
           restitution: nextPhysics.restitution ?? 0.5,
           friction: nextPhysics.friction ?? 5,
         });
-        m.parent = mParent;
+        m.setParent(mParent);
       });
     }
 

--- a/src/SceneBinding.ts
+++ b/src/SceneBinding.ts
@@ -622,10 +622,12 @@ class SceneBinding {
   };
 }
 
-const IMPOSTER_TYPE_MAPPINGS: { [key: string]: number } = {
+const IMPOSTER_TYPE_MAPPINGS: { [key in Node.Physics.Type]: number } = {
   'box': Babylon.PhysicsImpostor.BoxImpostor,
   'sphere': Babylon.PhysicsImpostor.SphereImpostor,
+  'cylinder': Babylon.PhysicsImpostor.CylinderImpostor,
   'mesh': Babylon.PhysicsImpostor.MeshImpostor,
+  'none': Babylon.PhysicsImpostor.NoImpostor,
 };
   
 

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -283,7 +283,7 @@ export class Space implements Robotable {
     const mesh = eventData.pickInfo.pickedMesh;
     const id = mesh.metadata as string;
     const prevId = store.getState().scene.selectedNodeId;
-    if (id !== prevId && store.getState().scene.nodes[id].editable) {
+    if (id !== prevId && store.getState().scene.nodes[id]?.editable) {
       store.dispatch(SceneAction.selectNode({ id }));
     } else {
       store.dispatch(SceneAction.UNSELECT_ALL);

--- a/src/components/World/AddNodeDialog.tsx
+++ b/src/components/World/AddNodeDialog.tsx
@@ -75,7 +75,7 @@ class AddNodeDialog extends React.PureComponent<Props, State> {
         physics: {
           mass: Mass.kilograms(1),
           friction: 5,
-          type: 'mesh',
+          type: 'box',
         }
       },
       geometryId,

--- a/src/components/World/NodeSettings.tsx
+++ b/src/components/World/NodeSettings.tsx
@@ -206,6 +206,17 @@ class NodeSettings extends React.PureComponent<Props, State> {
     const type = option.data as Geometry.Type;
 
     this.props.onGeometryChange(object.geometryId, Geometry.defaultFor(type));
+
+    const newPhysicsType = PHSYICS_TYPE_MAPPINGS[type];
+    if (node.physics && node.physics.type !== newPhysicsType) {
+      this.props.onNodeChange({
+        ...node,
+        physics: {
+          ...node.physics,
+          type: newPhysicsType,
+        }
+      });
+    }
   };
 
   private onCollapsedChange_ = (key: string) => (collapsed: boolean) => {
@@ -824,5 +835,15 @@ class NodeSettings extends React.PureComponent<Props, State> {
     );
   }
 }
+
+const PHSYICS_TYPE_MAPPINGS: { [key in Geometry.Type]: Node.Physics.Type } = {
+  'box': 'box',
+  'cone': 'mesh',
+  'cylinder': 'cylinder',
+  'file': 'mesh',
+  'mesh': 'mesh',
+  'plane': 'box',
+  'sphere': 'sphere',
+};
 
 export default NodeSettings;

--- a/src/state/State/Scene/Node.ts
+++ b/src/state/State/Scene/Node.ts
@@ -16,7 +16,7 @@ namespace Node {
   }
 
   export namespace Physics {
-    export type Type = 'box' | 'sphere' | 'mesh' | 'none';
+    export type Type = 'box' | 'sphere' | 'cylinder' | 'mesh' | 'none';
   
     export const diff = (prev: Physics, next: Physics): Patch<Physics> => {
       if (!deepNeq(prev, next)) return Patch.none(prev);

--- a/src/state/reducer/scene.ts
+++ b/src/state/reducer/scene.ts
@@ -1,7 +1,7 @@
 import Scene from "../State/Scene";
 import Node from "../State/Scene/Node";
 import Geometry from "../State/Scene/Geometry";
-import { Distance } from "../../util";
+import { Distance, Mass } from "../../util";
 import { ReferenceFrame, Vector3 } from "../../unit-math";
 import Camera from "../State/Scene/Camera";
 
@@ -250,6 +250,26 @@ export const TEST_SCENE: Scene = {
         restitution: 0,
         friction: 1
       },
+    },
+    'box0': {
+      type: 'object',
+      geometryId: 'box',
+      name: 'box0',
+      origin: {
+        position: {
+          x: Distance.meters(0.5),
+          y: Distance.meters(1.5),
+          z: Distance.meters(0),
+        },
+      },
+      editable: true,
+      visible: true,
+      physics: {
+        type: 'box',
+        mass: Mass.grams(100),
+        friction: 0.7,
+        restitution: 0.3,
+      }
     },
     'light0': {
       type: 'point-light',


### PR DESCRIPTION
(to be merged into `scene-description` branch, not `master`)

- Fix crazy behavior when editing physics properties
- Fix crash when non-scene meshes (like robot) are clicked
- Choose impostor type based on geometry type. `BoxImpostor` for boxes, `SphereImpostor` for spheres, etc. Also added `cylinder` as a supported physics type.
- Add box to test scene, for testing an editable scene object