### PR TITLE
Moved Feedback Submission to Server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,27 @@
-FROM emscripten/emsdk:2.0.2
+FROM ubuntu:20.04
+
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+ENV TZ=America/Los_Angeles
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && apt-get install -y wget git cmake build-essential doxygen
+
+RUN wget https://deb.nodesource.com/setup_17.x && chmod +x ./setup_17.x && ./setup_17.x
+RUN apt-get install -y nodejs
 
 RUN npm install -g yarn
+
+RUN git clone https://github.com/emscripten-core/emsdk
+WORKDIR /emsdk
+RUN ./emsdk install 2.0.2
+RUN ./emsdk activate 2.0.2
 
 ADD . /app
 
 WORKDIR /app/libwallaby
 RUN mkdir build
 WORKDIR /app/libwallaby/build
-RUN emcmake cmake -Demscripten=ON -Dno_wallaby=ON -Dwith_vision_support=OFF -Dbuild_python=OFF -DBUILD_DOCUMENTATION=OFF .. && make -j2
+RUN source /emsdk/emsdk_env.sh && emcmake cmake -Demscripten=ON -Dno_wallaby=ON -Dwith_vision_support=OFF -Dbuild_python=OFF -DBUILD_DOCUMENTATION=OFF .. && make -j2
 
 
 WORKDIR /app
@@ -16,5 +30,5 @@ EXPOSE 3000
 # WORKDIR /app/simulator
 # RUN yarn install --cache-folder ./.yarncache && yarn build; true
 RUN yarn install --cache-folder ./.yarncache
-RUN yarn build
-CMD node express.js
+RUN export NODE_OPTIONS=--openssl-legacy-provider && yarn build
+CMD NODE=$(which node)  source /emsdk/emsdk_env.sh && $NODE express.js

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ sudo ./install.sh
 ## Manual Setup
 
 ### Requirements
-- [Node.js v14 or higher](https://nodejs.org/)
+- [Node.js v16 or higher](https://nodejs.org/)
 - [yarn](https://classic.yarnpkg.com/)
 - Doxygen (libwallaby requirement)
 
@@ -57,7 +57,13 @@ git submodule update --init
 
 ### Install Emscripten
 
-See more info here: https://emscripten.org/docs/getting_started/downloads.html
+Emscripten requires Node v14, while we require Node v16. This isn't a big deal - just export the location of Node to a variable, which we'll then use later.
+```bash
+# run to get the location of Node v16
+NODE=$(which node)
+```
+
+See more info on Emscripten and installing it here: https://emscripten.org/docs/getting_started/downloads.html
 
 ```bash
 git clone https://github.com/emscripten-core/emsdk.git
@@ -94,9 +100,11 @@ yarn watch
 
 In another terminal, run the server:
 ```bash
+NODE=$(which node)
 source $PATH_TO_EMSDK/emsdk_env.sh
-node express.js
+$NODE express.js
 ```
+Note that you MUST run the server using Node v16. It is recommended to run the above three commands in a new terminal, as running `source $PATH_TO_EMSDK/emsdk_env.sh` will add it's own Node v14 binary to the PATH.
 
 ## Configuration
 
@@ -107,6 +115,7 @@ The server can be configured using environment variables. Variables without defa
 | `LIBWALLABY_ROOT` | Path to the root directory of libwallaby | `./libwallaby` |
 | `SERVER_PORT` | The port on which to listen for requests | `3000` |
 | `CACHING_STATIC_MAX_AGE` | The max duration (in ms) to allow static assets to be cached | `3600000` (1 hr) |
+| `FEEDBACK_WEBHOOK_URL` | The url for the discord webhook to send feedback to | | 
 
 ## Linting
 

--- a/config.js
+++ b/config.js
@@ -6,6 +6,7 @@ module.exports = {
       server: {
         port: getEnvVarOrDefault('SERVER_PORT', 3000),
         libwallabyRoot: getEnvVarOrDefault('LIBWALLABY_ROOT', './libwallaby'),
+        feedbackWebhookURL: getEnvVarOrDefault('FEEDBACK_WEBHOOK_URL', 'https://discord.com/api/webhooks/932033545344520302/INtF5qz2M4EllekYvYLKip-Hbyw-TTHkr6JQRoJQ0FafZ0_6dBrgvpw4O8YB5zN2vSAK'),
       },
       caching: {
         staticMaxAge: getEnvVarOrDefault('CACHING_STATIC_MAX_AGE', 60 * 60 * 1000),

--- a/express.js
+++ b/express.js
@@ -162,7 +162,7 @@ app.post('/feedback', (req, res) => {
     fs.writeFile(path, 
       JSON.stringify(req.body.state, undefined, 2),
       err => {
-        if (!err) {
+        if (err) {
           reject(`Failed to write user data - please try again`);
         }
 

--- a/express.js
+++ b/express.js
@@ -112,7 +112,7 @@ app.post('/compile', (req, res) => {
 });
 
 app.post('/feedback', (req, res) => {
-  const hook = 'https://discord.com/api/webhooks/931769619025379388/mZo-3RGXUYfN2DG9zV7u2ljnNUfyIJXFtNfh88T7QURew3_ISbAnntZ0Tml8TpEFBSTE';
+  const hook = config.server.feedbackWebhookURL;
   const body = req.body;
 
   const feedbackForm = new FormData();

--- a/express.js
+++ b/express.js
@@ -122,7 +122,7 @@ app.post('/feedback', (req, res) => {
 
   let content = `User Feedback Recieved:\n\`\`\`${body.feedback} \`\`\``;
   
-  content += `Sentiment:`;
+  content += `Sentiment: `;
   switch (body.sentiment) {
     case 0: content += 'No sentiment! This is probably a bug'; break;
     case 1: content += ':frowning2:'; break;

--- a/express.js
+++ b/express.js
@@ -162,7 +162,7 @@ app.post('/feedback', (req, res) => {
     fs.writeFile(path, 
       JSON.stringify(req.body.state, undefined, 2),
       err => {
-        if (err) {
+        if (!err) {
           reject(`Failed to write user data - please try again`);
         }
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
     "firebase": "^9.0.1",
+    "form-data": "^4.0.0",
     "image-loader": "^0.0.1",
     "image-webpack-loader": "^6.0.0",
     "ivygate": "https://github.com/kipr/ivygate#v0.1.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babylonjs-loaders": "^4.2.0",
     "body-parser": "^1.19.0",
     "css-loader": "^3.5.3",
+    "discord.js": "^13.6.0",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
     "firebase": "^9.0.1",

--- a/src/Feedback.ts
+++ b/src/Feedback.ts
@@ -11,6 +11,7 @@ export interface Feedback {
   email: string;
   includeAnonData: boolean;
   message: string;
+  error: boolean;
 }
   
 export const DEFAULT_FEEDBACK: Feedback = {
@@ -19,4 +20,5 @@ export const DEFAULT_FEEDBACK: Feedback = {
   email: "",
   includeAnonData: true,
   message: "",
+  error: false,
 };

--- a/src/components/Feedback/SuccessModal.tsx
+++ b/src/components/Feedback/SuccessModal.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { FeedbackText } from './FeedbackInputs';
+import { StyleProps } from '../../style';
+import { Dialog } from '../Dialog';
+import { ThemeProps } from '../theme';
+import { FeedbackContainer, CenterContainer } from './index';
+
+export interface FeedbackSuccessDialogProp extends ThemeProps, StyleProps {
+  onClose: () => void;
+}
+
+interface FeedbackSuccessDialogState {}
+
+type Props = FeedbackSuccessDialogProp;
+type State = FeedbackSuccessDialogState;
+
+export class FeedbackSuccessDialog extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      selectedSection: 'simulation',
+    };
+  }
+  
+  render() {
+    const { props, state } = this;
+    const { style, className, theme, onClose } = props;
+
+    return (
+      <Dialog theme={theme} name='Feedback Success' onClose={onClose}>
+        <FeedbackContainer theme={theme}>
+          <CenterContainer theme={theme}>
+            <FeedbackText>
+              <p>Feedback successfully submitted!</p>
+              <p>Thank you for helping improve the KIPR Simulator!</p>
+            </FeedbackText>
+          </CenterContainer>
+        </FeedbackContainer>
+      </Dialog>
+    );
+  }
+}

--- a/src/components/Feedback/index.tsx
+++ b/src/components/Feedback/index.tsx
@@ -165,7 +165,7 @@ export class FeedbackDialog extends React.PureComponent<Props, State> {
             <CenterContainer theme={theme}>
               <p>
                 <>Please try again, </>
-                <FeedbackLink href="https://github.com/kipr/Simulator/issues/new">
+                <FeedbackLink href="https://github.com/kipr/Simulator/issues" target="_blank">
                   open an issue on our github page,   
                 </FeedbackLink>
                 <> or </>

--- a/src/components/Feedback/index.tsx
+++ b/src/components/Feedback/index.tsx
@@ -166,9 +166,9 @@ export class FeedbackDialog extends React.PureComponent<Props, State> {
               <p>
                 <>Please try again, </>
                 <FeedbackLink href="https://github.com/kipr/Simulator/issues" target="_blank">
-                  open an issue on our github page,   
+                  open an issue on our github page
                 </FeedbackLink>
-                <> or </>
+                <>, or </>
                 <FeedbackLink href="mailto:info@kipr.org">
                   email KIPR.
                 </FeedbackLink>

--- a/src/components/Feedback/index.tsx
+++ b/src/components/Feedback/index.tsx
@@ -21,11 +21,11 @@ interface FeedbackDialogState {}
 type Props = FeedbackDialogProp;
 type State = FeedbackDialogState;
 
-const FeedbackContainer = styled('div', (props: ThemeProps) => ({
+export const FeedbackContainer = styled('div', (props: ThemeProps) => ({
   padding: `${props.theme.itemPadding * 2}px`,
 }));
 
-const CenterContainer = styled('div', (props: ThemeProps) => ({
+export const CenterContainer = styled('div', (props: ThemeProps) => ({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'center',
@@ -33,14 +33,14 @@ const CenterContainer = styled('div', (props: ThemeProps) => ({
   color: props.theme.color,
 }));
 
-const FeedbackRowContainer = styled('div', (props: ThemeProps) => ({
+export const FeedbackRowContainer = styled('div', (props: ThemeProps) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'flex-start',
   padding: `${props.theme.itemPadding * 2}px`,
 }));
 
-const FeedbackLink = styled('a', () => ({
+export const FeedbackLink = styled('a', () => ({
   color: 'lightblue',
 }));
 
@@ -110,7 +110,6 @@ export class FeedbackDialog extends React.PureComponent<Props, State> {
     const { props, state } = this;
     const { style, className, theme, onClose, onSubmit } = props;
 
-    // TODO: Better submit button themeing
     return (
       <Dialog theme={theme} name='Feedback' onClose={onClose}>
         <FeedbackContainer theme={theme}>

--- a/src/components/Feedback/index.tsx
+++ b/src/components/Feedback/index.tsx
@@ -29,6 +29,7 @@ const CenterContainer = styled('div', (props: ThemeProps) => ({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'center',
+  textAlign: 'center',
   color: props.theme.color,
 }));
 
@@ -37,6 +38,10 @@ const FeedbackRowContainer = styled('div', (props: ThemeProps) => ({
   flexDirection: 'row',
   alignItems: 'flex-start',
   padding: `${props.theme.itemPadding * 2}px`,
+}));
+
+const FeedbackLink = styled('a', () => ({
+  color: 'lightblue',
 }));
 
 export class FeedbackDialog extends React.PureComponent<Props, State> {
@@ -156,7 +161,20 @@ export class FeedbackDialog extends React.PureComponent<Props, State> {
               {this.props.feedback.message}
             </FeedbackText>
           </CenterContainer>
-          
+          {this.props.feedback.error &&
+            <CenterContainer theme={theme}>
+              <p>
+                <>Please try again, </>
+                <FeedbackLink href="https://github.com/kipr/Simulator/issues/new">
+                  open an issue on our github page,   
+                </FeedbackLink>
+                <> or </>
+                <FeedbackLink href="mailto:info@kipr.org">
+                  email KIPR.
+                </FeedbackLink>
+              </p>
+            </CenterContainer>
+          }
         </FeedbackContainer>
         <DialogBar theme={theme} onAccept={onSubmit}>
           <Fa icon='paper-plane'/> Submit

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -119,7 +119,7 @@ export class Root extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    
+
 
     this.state = {
       robotState: WorkerInstance.state,
@@ -204,7 +204,7 @@ export class Root extends React.Component<Props, State> {
   private onHideAll_ = () => {
     this.overlayLayout_.hideAll();
   };
-  
+
   private onLayoutChange_ = (layout: Layout) => {
     this.setState({
       layout
@@ -256,7 +256,7 @@ export class Root extends React.Component<Props, State> {
       text: `Compiling...\n`,
       style: STDOUT_STYLE(this.state.theme)
     }));
-    
+
     this.setState({
       simulatorState: SimulatorState.COMPILING,
       console: nextConsole
@@ -264,7 +264,7 @@ export class Root extends React.Component<Props, State> {
       compile(code)
         .then(js => {
           WorkerInstance.start(js);
-          
+
           nextConsole = StyledText.extend(nextConsole, StyledText.text({
             text: `Compilation succeeded!\n`,
             style: STDOUT_STYLE(this.state.theme)
@@ -294,7 +294,7 @@ export class Root extends React.Component<Props, State> {
           // TODO: handle cases where e is not a CompileError
           const compileError = e as CompileError;
           const messages = sort(parseMessages(compileError.stderr));
-  
+
           if (hasErrors(messages) || messages.length === 0) {
             nextConsole = StyledText.extend(nextConsole, StyledText.text({
               text: `Compilation failed.\n`,
@@ -310,7 +310,7 @@ export class Root extends React.Component<Props, State> {
               style: STDERR_STYLE(this.state.theme)
             }));
           }
-  
+
           for (const message of messages) {
             nextConsole = StyledText.extend(nextConsole, toStyledText(message, {
               onClick: message.ranges.length > 0
@@ -318,8 +318,8 @@ export class Root extends React.Component<Props, State> {
                 : undefined
             }));
           }
-  
-  
+
+
           this.setState({
             simulatorState: SimulatorState.STOPPED,
             messages,
@@ -372,15 +372,19 @@ export class Root extends React.Component<Props, State> {
   private onFeedbackChange_ = (changedFeedback: Partial<Feedback>) => {
     this.setState({ feedback: { ...this.state.feedback, ...changedFeedback } });
   };
-  
+
   private onFeedbackSubmit_ = () => {
     sendFeedback(this.state)
       .then((message: string) => {
+        console.log('message onFeedbackSubmit:', message);
         this.onFeedbackChange_(({ message: message }));
+        this.onFeedbackChange_(({ error: false }));
         this.onModalClose_();
       })
       .catch((error: string) => {
+        console.log('error onFeedbackSubmit:', error);
         this.onFeedbackChange_(({ message: error }));
+        this.onFeedbackChange_(({ error: true }));
       });
   };
 
@@ -448,7 +452,7 @@ export class Root extends React.Component<Props, State> {
       default: {
         return null;
       }
-      
+
     }
 
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1321,6 +1321,11 @@ async@^2.6.2:
   dependencies:
     lodash "^4.17.14"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
 atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -1819,6 +1824,13 @@ colorette@^1.2.1, colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^2.20.0, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -2229,6 +2241,11 @@ del@^4.1.1:
     p-map "^2.0.0"
     pify "^4.0.1"
     rimraf "^2.6.3"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
 depd@~1.1.2:
   version "1.1.2"
@@ -3114,6 +3131,15 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -4603,6 +4629,18 @@ mime-db@1.48.0, "mime-db@>= 1.43.0 < 2", mime-db@^1.28.0:
   version "1.48.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
   integrity sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
+
+mime-db@1.51.0:
+  version "1.51.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
+  integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
+
+mime-types@^2.1.12:
+  version "2.1.34"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
+  integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
+  dependencies:
+    mime-db "1.51.0"
 
 mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.24:
   version "2.1.31"

--- a/yarn.lock
+++ b/yarn.lock
@@ -241,6 +241,22 @@
     "@babel/helper-validator-identifier" "^7.14.5"
     to-fast-properties "^2.0.0"
 
+"@discordjs/builders@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-0.11.0.tgz#4102abe3e0cd093501f3f71931df43eb92f5b0cc"
+  integrity sha512-ZTB8yJdJKrKlq44dpWkNUrAtEJEq0gqpb7ASdv4vmq6/mZal5kOv312hQ56I/vxwMre+VIkoHquNUAfnTbiYtg==
+  dependencies:
+    "@sindresorhus/is" "^4.2.0"
+    discord-api-types "^0.26.0"
+    ts-mixer "^6.0.0"
+    tslib "^2.3.1"
+    zod "^3.11.6"
+
+"@discordjs/collection@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-0.4.0.tgz#b6488286a1cc7b41b644d7e6086f25a1c1e6f837"
+  integrity sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw==
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz#90420f9f9c6d3987f176a19a7d8e764271a2f55d"
@@ -730,10 +746,20 @@
   resolved "https://registry.yarnpkg.com/@rtsao/csstype/-/csstype-2.6.5-forked.0.tgz#b5b4e2a07ad83a91874ebf5fabdb73dc8c1632f6"
   integrity sha512-0HwnY8uPWcCloTgdbbaJG3MbDUfNf6yKWZfCKxFv9yj2Sbp4mSKaIjC7Cr/5L4hMxvrrk85CU3wlAg7EtBBJ1Q==
 
+"@sapphire/async-queue@^1.1.9":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.2.0.tgz#7a56afd318101d338433d7180ebd6af349243268"
+  integrity sha512-O5ND5Ljpef86X5oy8zXorQ754TMjWALcPSAgPBu4+76HLtDTrNoDyzU2uGE2G4A8Wv51u0MXHzGQ0WZ4GMtpIw==
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
+
+"@sindresorhus/is@^4.2.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.4.0.tgz#e277e5bdbdf7cb1e20d320f02f5e2ed113cd3185"
+  integrity sha512-QppPM/8l3Mawvh4rn9CNEYIU9bxpXUCRMaX9yUpvBk1nMKusLKpfXGDEKExKaPhLzcn3lzil7pR6rnJ11HgeRQ==
 
 "@types/eslint-scope@^3.7.0":
   version "3.7.1"
@@ -796,6 +822,14 @@
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
+
+"@types/node-fetch@^2.5.12":
+  version "2.5.12"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
+  integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
 
 "@types/node@*":
   version "16.0.1"
@@ -890,6 +924,13 @@
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.1.tgz#1a32969cf8f0364b3d8c8af9cc3555b7805df14f"
   integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
+
+"@types/ws@^8.2.2":
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.2.2.tgz#7c5be4decb19500ae6b3d563043cd407bf366c21"
+  integrity sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==
+  dependencies:
+    "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^4.18.0":
   version "4.28.2"
@@ -2274,6 +2315,26 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+discord-api-types@^0.26.0:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.26.1.tgz#726f766ddc37d60da95740991d22cb6ef2ed787b"
+  integrity sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ==
+
+discord.js@^13.6.0:
+  version "13.6.0"
+  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-13.6.0.tgz#d8a8a591dbf25cbcf9c783d5ddf22c4694860475"
+  integrity sha512-tXNR8zgsEPxPBvGk3AQjJ9ljIIC6/LOPjzKwpwz8Y1Q2X66Vi3ZqFgRHYwnHKC0jC0F+l4LzxlhmOJsBZDNg9g==
+  dependencies:
+    "@discordjs/builders" "^0.11.0"
+    "@discordjs/collection" "^0.4.0"
+    "@sapphire/async-queue" "^1.1.9"
+    "@types/node-fetch" "^2.5.12"
+    "@types/ws" "^8.2.2"
+    discord-api-types "^0.26.0"
+    form-data "^4.0.0"
+    node-fetch "^2.6.1"
+    ws "^8.4.0"
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
@@ -3131,6 +3192,15 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@^4.0.0:
   version "4.0.0"
@@ -4845,6 +4915,13 @@ node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^2.6.1:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -6813,6 +6890,11 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -6835,6 +6917,11 @@ ts-loader@^9.1.2:
     micromatch "^4.0.0"
     semver "^7.3.4"
 
+ts-mixer@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-6.0.0.tgz#4e631d3a36e3fa9521b973b132e8353bc7267f9f"
+  integrity sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ==
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -6845,7 +6932,7 @@ tslib@^2.0.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
-tslib@^2.1.0:
+tslib@^2.1.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -7079,6 +7166,11 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webpack-cli@^4.7.0:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.7.2.tgz#a718db600de6d3906a4357e059ae584a89f4c1a5"
@@ -7220,6 +7312,14 @@ whatwg-fetch@2.0.4:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
@@ -7300,6 +7400,11 @@ ws@^7.3.1:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.5.tgz#8b4bc4af518cfabd0473ae4f99144287b33eb881"
   integrity sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==
 
+ws@^8.4.0:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.4.2.tgz#18e749868d8439f2268368829042894b6907aa0b"
+  integrity sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==
+
 xtend@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
@@ -7379,3 +7484,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.11.6:
+  version "3.11.6"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.11.6.tgz#e43a5e0c213ae2e02aefe7cb2b1a6fa3d7f1f483"
+  integrity sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg==


### PR DESCRIPTION
Re-wrote the discord webhook submission to move it server-side, so that users can submit feedback even if discord is blocked, and without exposing the webhook URL to the public. Note that the final URL will need to be supplied as a server environmental variable, with the current URL functioning as a developer testing channel.

The user's data is sent to the server as a JSON POST request, where it is received, interpreted, and sent to a discord webhook.

Also note that this PR adds the dependency [form-data](https://www.npmjs.com/package/form-data), which is required for properly submitting the webhook POST request to discord.

Other enhancements:

- Made the error text more helpful, allowing users to email kipr or open an issue if feedback submission fails (github link directs to the issues page because you are required to log in to github to open an issue, and this felt a little more natural"). Note that the email address may need to be changed or removed if that's not desired.
- Made the error text centered

Known bugs:

- Feedback form does not clear on submission. This was originally intentional, so that users could see what they said after the fact, but is definitely bad design. This is trivial to fix.
- The Modal dialog is not centered vertically on the screen

Changes:

- Added a success modal and cleared the form on success (fixing the first bug above)
- Moved to using [Discord.js](https://discord.js.org/#/) on the server
- The Dockerfile likely will no longer work due to needing Nodev16. If the Dockerfile is important, I can work on fixing this (should be easy - just install the correct version of Node and use the install instructions), but someone with more Docker experience may be able to do this faster.