### PR TITLE
Remove default feedback URL

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,7 +6,7 @@ module.exports = {
       server: {
         port: getEnvVarOrDefault('SERVER_PORT', 3000),
         libwallabyRoot: getEnvVarOrDefault('LIBWALLABY_ROOT', './libwallaby'),
-        feedbackWebhookURL: getEnvVarOrDefault('FEEDBACK_WEBHOOK_URL', 'https://discord.com/api/webhooks/937955089870643260/1eClHG01mrZHhIN24mUPgt7UDi-hpagEk-QSZB58aaYrRZpgvwb-GaEDF3bBSDWHv6Aq'),
+        feedbackWebhookURL: getEnvVarOrDefault('FEEDBACK_WEBHOOK_URL', ''),
       },
       caching: {
         staticMaxAge: getEnvVarOrDefault('CACHING_STATIC_MAX_AGE', 60 * 60 * 1000),

--- a/express.js
+++ b/express.js
@@ -114,6 +114,13 @@ app.post('/compile', (req, res) => {
 
 app.post('/feedback', (req, res) => {
   const hookURL = config.server.feedbackWebhookURL;
+  if (!hookURL) {
+    res.status(500).json({
+      message: 'The feedback URL is not set on the server. If this is a developoment environment, make sure the feedback URL environment variable is set.'
+    });
+    return;
+  }
+
   const body = req.body;
 
   let content = `User Feedback Recieved:\n\`\`\`${body.feedback} \`\`\``;


### PR DESCRIPTION
Removing the default feedback URL so that it isn't public. Developers can set the feedback URL in their own config file.