### PR TITLE
[scene-description] Separate working/reference scenes to support reset

### DIFF
--- a/src/SceneBinding.ts
+++ b/src/SceneBinding.ts
@@ -24,6 +24,7 @@ class SceneBinding {
 
   private scene_: Scene;
   get scene() { return this.scene_; }
+  set scene(s: Scene) { this.scene_ = s; }
 
   private nodes_: Dict<Babylon.Node> = {};
 

--- a/src/components/Info/Info.tsx
+++ b/src/components/Info/Info.tsx
@@ -24,7 +24,7 @@ export interface InfoProps extends StyleProps, ThemeProps {
 
 interface ReduxInfoProps {
   startingOrigin: ReferenceFrame;
-  onOriginChange: (origin: ReferenceFrame) => void;
+  onOriginChange: (origin: ReferenceFrame, modifyReferenceScene: boolean) => void;
 }
 
 interface InfoState {
@@ -134,7 +134,7 @@ class Info extends React.PureComponent<Props & ReduxInfoProps, State> {
   private onResetLocationClick_ = (event: React.MouseEvent<HTMLSpanElement>) => {
     event.preventDefault();
     event.stopPropagation();
-    this.props.onOriginChange(this.props.startingOrigin);
+    this.props.onOriginChange(this.props.startingOrigin, false);
   };
 
   render() {
@@ -253,16 +253,12 @@ class Info extends React.PureComponent<Props & ReduxInfoProps, State> {
 }
 
 export default connect<unknown, unknown, InfoProps, ReduxState>((state: ReduxState) => {
-  const startingScene = state.scenes.scenes[state.scenes.activeId];
-  let startingOrigin = ReferenceFrame.IDENTITY;
-  if (startingScene.type === Async.Type.Loaded) {
-    startingOrigin = startingScene.value.robot?.origin || ReferenceFrame.IDENTITY;
-  }
+  const startingOrigin = state.scene.referenceScene.robot?.origin || ReferenceFrame.IDENTITY;
   return {
-    startingOrigin: startingOrigin,
+    startingOrigin,
   };
 }, dispatch => ({
-  onOriginChange: (origin: ReferenceFrame) => {
-    dispatch(SceneAction.setRobotOrigin({ origin }));
+  onOriginChange: (origin: ReferenceFrame, modifyReferenceScene: boolean) => {
+    dispatch(SceneAction.setRobotOrigin({ origin, modifyReferenceScene }));
   }
 }))(Info) as React.ComponentType<InfoProps>;

--- a/src/components/Info/Location.tsx
+++ b/src/components/Info/Location.tsx
@@ -20,9 +20,8 @@ export interface LocationProps extends ThemeProps, StyleProps {
 }
 
 export interface ReduxLocationProps {
-  startingOrigin: ReferenceFrame;
   origin: ReferenceFrame;
-  onOriginChange: (origin: ReferenceFrame) => void;
+  onOriginChange: (origin: ReferenceFrame, modifyReferenceScene: boolean) => void;
 }
 
 type Props = LocationProps;
@@ -61,7 +60,7 @@ class Location extends React.PureComponent<Props & ReduxLocationProps> {
         ...origin.position || Vector3.zero('centimeters'),
         x: xDistance
       }
-    });
+    }, true);
   };
 
   private onYChange_ = (y: Value) => {
@@ -76,7 +75,7 @@ class Location extends React.PureComponent<Props & ReduxLocationProps> {
         ...(origin.position || Vector3.zero('centimeters')),
         y: yDistance
       }
-    });
+    }, true);
   };
 
   private onZChange_ = (z: Value) => {
@@ -91,7 +90,7 @@ class Location extends React.PureComponent<Props & ReduxLocationProps> {
         ...(origin.position || Vector3.zero('centimeters')),
         z: zDistance
       }
-    });
+    }, true);
   };
 
   private onThetaChange_ = (theta: Value) => {
@@ -113,7 +112,7 @@ class Location extends React.PureComponent<Props & ReduxLocationProps> {
     this.props.onOriginChange({
       ...origin,
       orientation: nextOrientation
-    });
+    }, true);
   };
   
   render() {
@@ -141,17 +140,12 @@ class Location extends React.PureComponent<Props & ReduxLocationProps> {
 }
 
 export default connect<unknown, unknown, LocationProps, State>((state: State) => {
-  const startingScene = state.scenes.scenes[state.scenes.activeId];
-  let startingOrigin = IDENTITY_ORIGIN;
-  if (startingScene.type === Async.Type.Loaded) {
-    startingOrigin = startingScene.value.robot?.origin || IDENTITY_ORIGIN;
-  }
+  const origin = state.scene.referenceScene.robot?.origin || IDENTITY_ORIGIN;
   return {
-    startingOrigin: startingOrigin,
-    origin: state.scene.robot?.origin || IDENTITY_ORIGIN,
+    origin,
   };
 }, dispatch => ({
-  onOriginChange: (origin: ReferenceFrame) => {
-    dispatch(SceneAction.setRobotOrigin({ origin }));
+  onOriginChange: (origin: ReferenceFrame, modifyReferenceScene: boolean) => {
+    dispatch(SceneAction.setRobotOrigin({ origin, modifyReferenceScene }));
   }
 }))(Location) as React.ComponentType<LocationProps>;

--- a/src/components/OverlayLayout.tsx
+++ b/src/components/OverlayLayout.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
 
 import { styled } from 'styletron-react';
 import { Button } from './Button';
@@ -11,9 +12,15 @@ import { SimulatorArea } from './SimulatorArea';
 import { Theme, ThemeProps } from './theme';
 import Widget, { BarComponent, Mode, Size, WidgetProps } from './Widget';
 import World from './World';
+import { State as ReduxState } from '../state';
+import { SceneAction } from '../state/reducer';
 
 export interface OverlayLayoutProps extends LayoutProps {
   
+}
+
+interface ReduxOverlayLayoutProps {
+  onResetScene: () => void;
 }
 
 interface OverlayLayoutState {
@@ -164,8 +171,8 @@ const INFO_SIZE = sizeDict(INFO_SIZES);
 const WORLD_SIZE = sizeDict(WORLD_SIZES);
 const CONSOLE_SIZE = sizeDict(CONSOLE_SIZES);
 
-class OverlayLayout extends React.PureComponent<Props, State> {
-  constructor(props: Props) {
+export class OverlayLayout extends React.PureComponent<Props & ReduxOverlayLayoutProps, State> {
+  constructor(props: Props & ReduxOverlayLayoutProps) {
     super(props);
 
     this.state = {
@@ -294,7 +301,8 @@ class OverlayLayout extends React.PureComponent<Props, State> {
       messages,
       settings,
       onClearConsole,
-      onSelectScene
+      onSelectScene,
+      onResetScene,
     } = props;
 
     const {
@@ -364,6 +372,16 @@ class OverlayLayout extends React.PureComponent<Props, State> {
         </>,
     }));
 
+    worldBar.push(BarComponent.create(Button, {
+      theme,
+      onClick: onResetScene,
+      children:
+        <>
+          <Fa icon='sync' />
+          { ' Reset' }
+        </>
+    }));
+
     return (
       <Container style={style} className={className}>
         <SimulatorAreaContainer>
@@ -424,4 +442,10 @@ class OverlayLayout extends React.PureComponent<Props, State> {
   }
 }
 
-export default OverlayLayout;
+export const OverlayLayoutRedux = connect<unknown, ReduxOverlayLayoutProps, OverlayLayoutProps, ReduxState>((state: ReduxState) => {
+  return {};
+}, dispatch => ({
+  onResetScene: () => {
+    dispatch(SceneAction.RESET_SCENE);
+  }
+}), null, { forwardRef: true })(OverlayLayout);

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -8,7 +8,7 @@ import SimMenu from './SimMenu';
 
 import { styled } from 'styletron-react';
 import { DARK, Theme } from './theme';
-import OverlayLayout from './OverlayLayout';
+import { OverlayLayout, OverlayLayoutRedux } from './OverlayLayout';
 import { Layout, LayoutProps } from './Layout';
 import BottomLayout from './BottomLayout';
 import SideLayout from './SideLayout';
@@ -431,7 +431,7 @@ export class Root extends React.Component<Props, State> {
     switch (layout) {
       case Layout.Overlay: {
         impl = (
-          <OverlayLayout ref={this.bindOverlayLayout_} {...commonLayoutProps} />
+          <OverlayLayoutRedux ref={this.bindOverlayLayout_} {...commonLayoutProps} />
         );
         break;
       }

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -13,15 +13,19 @@ const global = window as any;
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
-export default createStore(combineReducers({
+export default createStore(combineReducers<State>({
   scene: reducer.reduceScene,
   scenes: reducer.reduceScenes
 }), global.__REDUX_DEVTOOLS_EXTENSION__ && global.__REDUX_DEVTOOLS_EXTENSION__());
 /* eslint-enable @typescript-eslint/no-unsafe-call */
 /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 
-
 export interface State {
-  scene: Scene;
+  scene: ReferencedScenePair;
   scenes: Scenes;
+}
+
+export interface ReferencedScenePair {
+  referenceScene: Scene;
+  workingScene: Scene;
 }


### PR DESCRIPTION
(to be merged into `scene-description` branch, not `master`)

- Separates the Redux scene into two separate scenes: the "working scene" (synced with Babylon's scene) and the "reference scene" (clean scene that allows us to reset nodes to their original state).
- Babylon -> Redux sync for robot position, similar to how item positions are synced (check if the robot has moved/rotated a significant enough amount).
- Display the "reset" button for all items, even non-editable ones
- Add a "Reset scene" button