### PR TITLE
[scene-description] Fix more scene-description bugs

### DIFF
--- a/src/components/World/AddNodeDialog.tsx
+++ b/src/components/World/AddNodeDialog.tsx
@@ -111,8 +111,6 @@ class AddNodeDialog extends React.PureComponent<Props, State> {
   };
 
   private onGeometryAdd_ = (id: string, geometry: Geometry) => {
-    if (id !== this.state.geometryId) return;
-
     this.setState({
       geometryId: id,
       geometry
@@ -124,7 +122,8 @@ class AddNodeDialog extends React.PureComponent<Props, State> {
     const { theme, onClose, scene } = props;
     const { node, id } = state;
 
-    const modifiedScene: Scene = {
+    // If there's a geometry in progress, create a temporary scene containing the geometry
+    const modifiedScene: Scene = !state.geometryId ? scene : {
       ...scene,
       geometry: {
         ...scene.geometry,

--- a/src/components/World/NodeSettings.tsx
+++ b/src/components/World/NodeSettings.tsx
@@ -18,6 +18,7 @@ import Node from "../../state/State/Scene/Node";
 import Scene from "../../state/State/Scene";
 import Dict from "../../Dict";
 
+import * as uuid from 'uuid';
 
 export interface NodeSettingsProps extends ThemeProps {
   onNodeChange: (node: Node) => void;
@@ -183,9 +184,35 @@ class NodeSettings extends React.PureComponent<Props, State> {
   private onTypeSelect_ = (index: number, option: ComboBox.Option) => {
     const { node } = this.props;
     
-    this.props.onNodeChange({
-      ...Node.transmute(node, option.data as Node.Type)
-    });
+    // If the type didn't change, do nothing
+    const selectedType = option.data as Node.Type;
+    if (node.type === selectedType) {
+      return;
+    }
+
+    let transmutedNode = Node.transmute(node, selectedType);
+
+    // If the new type is an object, add a new geometry and reset the physics type
+    if (transmutedNode.type === 'object') {
+      const defaultGeometryType: Geometry.Type = 'box';
+
+      transmutedNode = {
+        ...transmutedNode,
+        geometryId: uuid.v4(),
+        physics: {
+          ...transmutedNode.physics,
+          type: PHSYICS_TYPE_MAPPINGS[defaultGeometryType],
+        },
+      };
+      this.props.onGeometryAdd(transmutedNode.geometryId, Geometry.defaultFor(defaultGeometryType));
+    }
+
+    this.props.onNodeChange({ ...transmutedNode });
+
+    // If the old type was an object, remove the old geometry
+    if (node.type === 'object') {
+      this.props.onGeometryRemove(node.geometryId);
+    }
   };
 
   private onParentSelect_ = (index: number, option: ComboBox.Option) => {

--- a/src/components/World/NodeSettings.tsx
+++ b/src/components/World/NodeSettings.tsx
@@ -123,6 +123,7 @@ class NodeSettings extends React.PureComponent<Props, State> {
       collapsed: {
         position: true,
         orientation: true,
+        scale: true,
         physics: true,
       }
     };

--- a/src/scenes/jbc15b.ts
+++ b/src/scenes/jbc15b.ts
@@ -34,7 +34,6 @@ export const JBC_15B: Scene = {
         friction: 1,
         mass: Mass.pounds(5),
       },
-      editable: true,
     },
     'ream2': {
       type: 'object',
@@ -58,7 +57,6 @@ export const JBC_15B: Scene = {
         friction: 1,
         mass: Mass.pounds(5),
       },
-      editable: true,
     },
   },
   // The normal starting position of the robot doesn't leave room for the paper ream in the starting box


### PR DESCRIPTION
(to be merged into `scene-description` branch, not `master`)

- Handle geometry changes in `SceneBinding`. Otherwise changing the geometry (such as changing a box's size) has no effect
- Fix bug where selecting "Object" in the type dropdown caused a crash
- In node settings dialog, collapse the "Scale" section by default
- Fix bug where touch sensors weren't working
- Fix bug where paper reams were editable in JBC challenge 15B