### PR TITLE
[scene-description] Move `physics` to `Obj`

### DIFF
--- a/src/components/World/NodeSettings.tsx
+++ b/src/components/World/NodeSettings.tsx
@@ -228,11 +228,11 @@ class NodeSettings extends React.PureComponent<Props, State> {
     const { props } = this;
     const { node } = props;
     
-    const object = node as Node.Obj;
+    if (node.type !== 'object') return;
 
     const type = option.data as Geometry.Type;
 
-    this.props.onGeometryChange(object.geometryId, Geometry.defaultFor(type));
+    this.props.onGeometryChange(node.geometryId, Geometry.defaultFor(type));
 
     const newPhysicsType = PHSYICS_TYPE_MAPPINGS[type];
     if (node.physics && node.physics.type !== newPhysicsType) {
@@ -475,6 +475,8 @@ class NodeSettings extends React.PureComponent<Props, State> {
 
   private onMassChange_ = (value: Value) => {
     const { node } = this.props;
+    if (node.type !== 'object') return;
+
     this.props.onNodeChange({
       ...node,
       physics: {
@@ -486,6 +488,8 @@ class NodeSettings extends React.PureComponent<Props, State> {
 
   private onFrictionChange_ = (value: Value) => {
     const { node } = this.props;
+    if (node.type !== 'object') return;
+    
     this.props.onNodeChange({
       ...node,
       physics: {
@@ -601,7 +605,7 @@ class NodeSettings extends React.PureComponent<Props, State> {
     let friction = UnitlessValue.create(5);
     let mass: Mass = Mass.grams(5);
 
-    if (node.physics) {
+    if (node.type === 'object' && node.physics) {
       if (node.physics.friction !== undefined) friction = UnitlessValue.create(node.physics.friction);
       if (node.physics.mass !== undefined) mass = node.physics.mass;
     }
@@ -847,16 +851,17 @@ class NodeSettings extends React.PureComponent<Props, State> {
             theme={theme}
           />
         </Section>
-        <Section
-          name='Physics'
-          theme={theme}
-          collapsed={collapsed['physics']}
-          onCollapsedChange={this.onCollapsedChange_('physics')}
-          noBorder
-        >
-          <StyledValueEdit name='Mass' value={Value.mass(mass)} onValueChange={this.onMassChange_} theme={theme} />
-          <StyledValueEdit name='Friction' value={Value.unitless(friction)} onValueChange={this.onFrictionChange_} theme={theme} />
-        </Section>
+        {node.type === 'object' && (
+          <Section
+            name='Physics'
+            theme={theme}
+            collapsed={collapsed['physics']}
+            onCollapsedChange={this.onCollapsedChange_('physics')}
+            noBorder
+          >
+            <StyledValueEdit name='Mass' value={Value.mass(mass)} onValueChange={this.onMassChange_} theme={theme} />
+            <StyledValueEdit name='Friction' value={Value.unitless(friction)} onValueChange={this.onFrictionChange_} theme={theme} />
+          </Section>)}
         
       </Container>
     );

--- a/src/state/State/Scene/Node.ts
+++ b/src/state/State/Scene/Node.ts
@@ -36,7 +36,6 @@ namespace Node {
     name: string;
     parentId?: string;
     origin?: ReferenceFrame;
-    physics?: Physics;
     scriptIds?: string[];
     documentIds?: string[];
     editable?: boolean;
@@ -48,7 +47,6 @@ namespace Node {
       name: '',
       parentId: undefined,
       origin: undefined,
-      physics: undefined,
       scriptIds: undefined,
       documentIds: undefined,
       editable: undefined,
@@ -59,7 +57,6 @@ namespace Node {
       name: t.name,
       parentId: t.parentId,
       origin: t.origin,
-      physics: t.physics,
       scriptIds: t.scriptIds,
       documentIds: t.documentIds,
       editable: t.editable,
@@ -70,7 +67,6 @@ namespace Node {
       name: Patch.diff(prev.name, next.name),
       parentId: Patch.diff(prev.parentId, next.parentId),
       origin: Patch.diff(prev.origin, next.origin),
-      physics: Patch.diff(prev.physics, next.physics),
       scriptIds: Patch.diff(prev.scriptIds, next.scriptIds),
       documentIds: Patch.diff(prev.documentIds, next.documentIds),
       editable: Patch.diff(prev.editable, next.editable),
@@ -106,6 +102,7 @@ namespace Node {
   export interface Obj extends Base {
     type: 'object';
     geometryId: string;
+    physics?: Physics;
   }
 
   export namespace Obj {
@@ -126,6 +123,7 @@ namespace Node {
       return Patch.innerChange(prev, next, {
         type: Patch.none(prev.type),
         geometryId: Patch.diff(prev.geometryId, next.geometryId),
+        physics: Patch.diff(prev.physics, next.physics),
         ...Base.partialDiff(prev, next)
       });
     };


### PR DESCRIPTION
(to be merged into `scene-description` branch, not `master`)

Move `physics` from `Base` to `Obj`. I don't think non-`Obj` nodes will ever need physics properties