### PR TITLE
[scene-description] Add material to cans/reams

### DIFF
--- a/src/node-templates/index.ts
+++ b/src/node-templates/index.ts
@@ -1,4 +1,6 @@
 import Dict from "../Dict";
+import { Vector2 } from "../math";
+import { Color } from "../state/State/Scene/Color";
 import Geometry from "../state/State/Scene/Geometry";
 import Node from "../state/State/Scene/Node";
 import { Distance, Mass } from "../util";
@@ -14,6 +16,14 @@ const canTemplate: Node.TemplatedNode<Node.Obj> = {
     friction: 0.7,
     restitution: 0.3,
   },
+  material: {
+    type: 'basic',
+    color: {
+      type: 'texture',
+      uri: '/static/Can Texture.png'
+    },
+  },
+  faceUvs: [Vector2.ZERO, Vector2.ZERO, Vector2.create(1, 0), Vector2.create(0, 1), Vector2.ZERO, Vector2.ZERO],
 };
 
 const reamTemplate: Node.TemplatedNode<Node.Obj> = {
@@ -24,6 +34,13 @@ const reamTemplate: Node.TemplatedNode<Node.Obj> = {
     restitution: 0,
     friction: 1,
     mass: Mass.pounds(5),
+  },
+  material: {
+    type: 'basic',
+    color: {
+      type: 'color3',
+      color: Color.Rgb.create(250, 249, 246),
+    },
   },
 };
 

--- a/src/state/State/Scene/Node.ts
+++ b/src/state/State/Scene/Node.ts
@@ -1,5 +1,5 @@
 import deepNeq from '../../../deepNeq';
-import { Vector3 } from '../../../math';
+import { Vector2, Vector3 } from '../../../math';
 import { ReferenceFrame } from '../../../unit-math';
 import { Angle, DistributiveOmit, Mass } from '../../../util';
 import Material from './Material';
@@ -105,6 +105,7 @@ namespace Node {
     geometryId: string;
     physics?: Physics;
     material?: Material;
+    faceUvs?: Vector2[];
   }
 
   export namespace Obj {
@@ -131,6 +132,7 @@ namespace Node {
         geometryId: Patch.diff(prev.geometryId, next.geometryId),
         physics: Patch.diff(prev.physics, next.physics),
         material: Material.diff(prev.material, next.material),
+        faceUvs: Patch.diff(prev.faceUvs, next.faceUvs),
         ...Base.partialDiff(prev, next)
       });
     };


### PR DESCRIPTION
(to be merged into `scene-description`, not `master`)

Adds materials back to cans and paper reams. Object nodes now have a `faceUvs` property so that we can do basic UV mappings, particularly for cylinders.