### PR TITLE
Move origin back to the starting box

### DIFF
--- a/src/components/World/AddNodeDialog.tsx
+++ b/src/components/World/AddNodeDialog.tsx
@@ -60,7 +60,7 @@ class AddNodeDialog extends React.PureComponent<Props, State> {
           position: {
             x: Distance.centimeters(0),
             y: Distance.centimeters(0),
-            z: Distance.centimeters(0),
+            z: Distance.centimeters(50),
           },
           orientation: {
             type: 'euler',

--- a/src/scenes/jbc10.ts
+++ b/src/scenes/jbc10.ts
@@ -11,6 +11,6 @@ export const JBC_10: Scene = {
   description: 'Junior Botball Challenge 10: Solo Joust',
   nodes: {
     ...baseScene.nodes,
-    'can1': createCanNode(1, { x: Distance.centimeters(-11), y: Distance.centimeters(0), z: Distance.centimeters(41) }),
+    'can1': createCanNode(1, { x: Distance.centimeters(-11), y: Distance.centimeters(0), z: Distance.centimeters(91) }),
   }
 };

--- a/src/scenes/jbc10b.ts
+++ b/src/scenes/jbc10b.ts
@@ -11,9 +11,9 @@ export const JBC_10B: Scene = {
   description: 'Junior Botball Challenge 10: Solo Joust Jr.',
   nodes: {
     ...baseScene.nodes,
-    'can1': createCanNode(1, { x: Distance.centimeters(13), y: Distance.centimeters(0), z: Distance.centimeters(-33) }), // green line
-    'can2': createCanNode(2, { x: Distance.centimeters(17), y: Distance.centimeters(0), z: Distance.centimeters(-9) }), // red line
-    'can3': createCanNode(3, { x: Distance.centimeters(-11.5), y: Distance.centimeters(0), z: Distance.centimeters(1) }), // yellow line
-    'can4': createCanNode(4, { x: Distance.centimeters(-10.5), y: Distance.centimeters(0), z: Distance.centimeters(-27) }), // purple line
+    'can1': createCanNode(1, { x: Distance.centimeters(13), y: Distance.centimeters(0), z: Distance.centimeters(17) }), // green line
+    'can2': createCanNode(2, { x: Distance.centimeters(17), y: Distance.centimeters(0), z: Distance.centimeters(41) }), // red line
+    'can3': createCanNode(3, { x: Distance.centimeters(-11.5), y: Distance.centimeters(0), z: Distance.centimeters(51) }), // yellow line
+    'can4': createCanNode(4, { x: Distance.centimeters(-10.5), y: Distance.centimeters(0), z: Distance.centimeters(23) }), // purple line
   }
 };

--- a/src/scenes/jbc12.ts
+++ b/src/scenes/jbc12.ts
@@ -11,8 +11,8 @@ export const JBC_12: Scene = {
   description: `Junior Botball Challenge 12: Unload 'Em`,
   nodes: {
     ...baseScene.nodes,
-    'can1': createCanNode(1, { x: Distance.centimeters(0), y: Distance.centimeters(0), z: Distance.centimeters(3.3) }),
-    'can2': createCanNode(2, { x: Distance.centimeters(-18.5), y: Distance.centimeters(0), z: Distance.centimeters(28) }),
-    'can3': createCanNode(3, { x: Distance.centimeters(12.3), y: Distance.centimeters(0), z: Distance.centimeters(43.9) }),
+    'can1': createCanNode(1, { x: Distance.centimeters(0), y: Distance.centimeters(0), z: Distance.centimeters(53.3) }),
+    'can2': createCanNode(2, { x: Distance.centimeters(-18.5), y: Distance.centimeters(0), z: Distance.centimeters(78) }),
+    'can3': createCanNode(3, { x: Distance.centimeters(12.3), y: Distance.centimeters(0), z: Distance.centimeters(93.9) }),
   }
 };

--- a/src/scenes/jbc15b.ts
+++ b/src/scenes/jbc15b.ts
@@ -20,7 +20,7 @@ export const JBC_15B: Scene = {
         position: {
           x: Distance.centimeters(0),
           y: Distance.centimeters(5),
-          z: Distance.centimeters(-2),
+          z: Distance.centimeters(48),
         },
         orientation: Rotation.AngleAxis.fromRaw({
           axis: { x: 1, y: 0, z: 0 },
@@ -37,7 +37,7 @@ export const JBC_15B: Scene = {
         position: {
           x: Distance.centimeters(0),
           y: Distance.centimeters(5),
-          z: Distance.centimeters(-56.3),
+          z: Distance.centimeters(-6.3),
         },
         orientation: Rotation.AngleAxis.fromRaw({
           axis: { x: 1, y: 0, z: 0 },
@@ -56,7 +56,7 @@ export const JBC_15B: Scene = {
       position: {
         x: Distance.centimeters(0),
         y: Distance.centimeters(2),
-        z: Distance.centimeters(-43),
+        z: Distance.centimeters(7),
       },
     }
   },

--- a/src/scenes/jbc17.ts
+++ b/src/scenes/jbc17.ts
@@ -17,7 +17,7 @@ export const JBC_17: Scene = {
       position: {
         x: Distance.centimeters(16.5),
         y: Distance.centimeters(2),
-        z: Distance.centimeters(-50),
+        z: Distance.centimeters(0),
       },
     }
   },

--- a/src/scenes/jbc17b.ts
+++ b/src/scenes/jbc17b.ts
@@ -17,7 +17,7 @@ export const JBC_17B: Scene = {
       position: {
         x: Distance.centimeters(16.5),
         y: Distance.centimeters(2),
-        z: Distance.centimeters(-50),
+        z: Distance.centimeters(0),
       },
     }
   },

--- a/src/scenes/jbc19.ts
+++ b/src/scenes/jbc19.ts
@@ -12,9 +12,9 @@ export const JBC_19: Scene = {
   description: `Junior Botball Challenge 19: Mountain Rescue`,
   nodes: {
     ...baseScene.nodes,
-    'can1': createCanNode(1, { x: Distance.centimeters(3), y: Distance.centimeters(6), z: Distance.centimeters(34.6) }),
-    'can2': createCanNode(2, { x: Distance.centimeters(10), y: Distance.centimeters(6), z: Distance.centimeters(41.6) }),
-    'can3': createCanNode(3, { x: Distance.centimeters(17), y: Distance.centimeters(6), z: Distance.centimeters(48.6) }),
+    'can1': createCanNode(1, { x: Distance.centimeters(3), y: Distance.centimeters(6), z: Distance.centimeters(84.6) }),
+    'can2': createCanNode(2, { x: Distance.centimeters(10), y: Distance.centimeters(6), z: Distance.centimeters(91.6) }),
+    'can3': createCanNode(3, { x: Distance.centimeters(17), y: Distance.centimeters(6), z: Distance.centimeters(98.6) }),
     'ream': {
       type: 'from-template',
       templateId: 'ream',
@@ -23,7 +23,7 @@ export const JBC_19: Scene = {
         position: {
           x: Distance.centimeters(10),
           y: Distance.centimeters(-3),
-          z: Distance.centimeters(41.6),
+          z: Distance.centimeters(91.6),
         },
         orientation: Rotation.AngleAxis.fromRaw({
           axis: { x: 0, y: 1, z: 0 },

--- a/src/scenes/jbc20.ts
+++ b/src/scenes/jbc20.ts
@@ -23,7 +23,7 @@ export const JBC_20: Scene = {
         position: {
           x: Distance.centimeters(12),
           y: Distance.centimeters(-3),
-          z: Distance.centimeters(-47),
+          z: Distance.centimeters(3),
         },
       },
       visible: true,
@@ -38,7 +38,7 @@ export const JBC_20: Scene = {
       position: {
         x: Distance.centimeters(-18),
         y: Distance.centimeters(2),
-        z: Distance.centimeters(-50),
+        z: Distance.centimeters(0),
       },
     }
   },

--- a/src/scenes/jbc6c.ts
+++ b/src/scenes/jbc6c.ts
@@ -11,8 +11,8 @@ export const JBC_6C: Scene = {
   description: `Junior Botball Challenge 6C: Empty the Garage`,
   nodes: {
     ...baseScene.nodes,
-    'can1': createCanNode(1, { x: Distance.centimeters(0), y: Distance.centimeters(0), z: Distance.centimeters(3.3) }),
-    'can2': createCanNode(2, { x: Distance.centimeters(-18.5), y: Distance.centimeters(0), z: Distance.centimeters(28) }),
-    'can3': createCanNode(3, { x: Distance.centimeters(12.3), y: Distance.centimeters(0), z: Distance.centimeters(43.9) }),
+    'can1': createCanNode(1, { x: Distance.centimeters(0), y: Distance.centimeters(0), z: Distance.centimeters(53.3) }),
+    'can2': createCanNode(2, { x: Distance.centimeters(-18.5), y: Distance.centimeters(0), z: Distance.centimeters(78) }),
+    'can3': createCanNode(3, { x: Distance.centimeters(12.3), y: Distance.centimeters(0), z: Distance.centimeters(93.9) }),
   }
 };

--- a/src/scenes/jbc7b.ts
+++ b/src/scenes/jbc7b.ts
@@ -11,13 +11,13 @@ export const JBC_7B: Scene = {
   description: `Junior Botball Challenge 7B: Cover Your Bases`,
   nodes: {
     ...baseScene.nodes,
-    'can1': createCanNode(1, { x: Distance.centimeters(-24), y: Distance.centimeters(0), z: Distance.centimeters(-34.5) }),
-    'can2': createCanNode(2, { x: Distance.centimeters(-16), y: Distance.centimeters(0), z: Distance.centimeters(-34.5) }),
-    'can3': createCanNode(3, { x: Distance.centimeters(-8), y: Distance.centimeters(0), z: Distance.centimeters(-34.5) }),
-    'can4': createCanNode(4, { x: Distance.centimeters(0), y: Distance.centimeters(0), z: Distance.centimeters(-34.5) }),
-    'can5': createCanNode(5, { x: Distance.centimeters(8), y: Distance.centimeters(0), z: Distance.centimeters(-34.5) }),
-    'can6': createCanNode(7, { x: Distance.centimeters(16), y: Distance.centimeters(0), z: Distance.centimeters(-34.5) }),
-    'can7': createCanNode(6, { x: Distance.centimeters(24), y: Distance.centimeters(0), z: Distance.centimeters(-34.5) }),
+    'can1': createCanNode(1, { x: Distance.centimeters(-24), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
+    'can2': createCanNode(2, { x: Distance.centimeters(-16), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
+    'can3': createCanNode(3, { x: Distance.centimeters(-8), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
+    'can4': createCanNode(4, { x: Distance.centimeters(0), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
+    'can5': createCanNode(5, { x: Distance.centimeters(8), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
+    'can6': createCanNode(7, { x: Distance.centimeters(16), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
+    'can7': createCanNode(6, { x: Distance.centimeters(24), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
   },
   // The normal starting position of the robot covers the tape
   // Start the robot back a bit so that a can fits on the tape in front of the robot
@@ -28,7 +28,7 @@ export const JBC_7B: Scene = {
       position: {
         x: Distance.centimeters(0),
         y: Distance.centimeters(2),
-        z: Distance.centimeters(-58),
+        z: Distance.centimeters(-8),
       },
     }
   }

--- a/src/scenes/jbcBase.ts
+++ b/src/scenes/jbcBase.ts
@@ -27,7 +27,7 @@ export function createBaseSceneSurfaceA(): Scene {
           position: {
             x: Distance.centimeters(0),
             y: Distance.centimeters(-7),
-            z: Distance.centimeters(0),
+            z: Distance.centimeters(50),
           },
           scale: {
             x: 100,
@@ -45,7 +45,7 @@ export function createBaseSceneSurfaceA(): Scene {
           position: {
             x: Distance.centimeters(0),
             y: Distance.centimeters(-7.2),
-            z: Distance.centimeters(0),
+            z: Distance.centimeters(50),
           },
           orientation: {
             type: 'euler',
@@ -69,7 +69,7 @@ export function createBaseSceneSurfaceA(): Scene {
           position: {
             x: Distance.meters(0),
             y: Distance.meters(0.91),
-            z: Distance.meters(0),
+            z: Distance.meters(0.5),
           },
         },
         visible: true
@@ -80,7 +80,7 @@ export function createBaseSceneSurfaceA(): Scene {
         position: {
           x: Distance.centimeters(0),
           y: Distance.centimeters(2),
-          z: Distance.centimeters(-50),
+          z: Distance.centimeters(0),
         },
       }
     },
@@ -89,12 +89,12 @@ export function createBaseSceneSurfaceA(): Scene {
       target: {
         x: Distance.meters(0),
         y: Distance.meters(0),
-        z: Distance.meters(0),
+        z: Distance.meters(0.5),
       },
       position: {
         x: Distance.meters(1),
         y: Distance.meters(0.91),
-        z: Distance.meters(1),
+        z: Distance.meters(1.5),
       }
     }),
     gravity: {
@@ -128,7 +128,7 @@ export function createBaseSceneSurfaceB(): Scene {
           position: {
             x: Distance.centimeters(0),
             y: Distance.centimeters(-7),
-            z: Distance.centimeters(0),
+            z: Distance.centimeters(50),
           },
           scale: {
             x: 100,
@@ -146,7 +146,7 @@ export function createBaseSceneSurfaceB(): Scene {
           position: {
             x: Distance.centimeters(0),
             y: Distance.centimeters(-7.2),
-            z: Distance.centimeters(0),
+            z: Distance.centimeters(50),
           },
           orientation: {
             type: 'euler',
@@ -170,7 +170,7 @@ export function createBaseSceneSurfaceB(): Scene {
           position: {
             x: Distance.meters(0),
             y: Distance.meters(0.91),
-            z: Distance.meters(0),
+            z: Distance.meters(0.5),
           },
         },
         visible: true
@@ -181,7 +181,7 @@ export function createBaseSceneSurfaceB(): Scene {
         position: {
           x: Distance.centimeters(0),
           y: Distance.centimeters(2),
-          z: Distance.centimeters(-50),
+          z: Distance.centimeters(0),
         },
       }
     },
@@ -190,12 +190,12 @@ export function createBaseSceneSurfaceB(): Scene {
       target: {
         x: Distance.meters(0),
         y: Distance.meters(0),
-        z: Distance.meters(0),
+        z: Distance.meters(0.5),
       },
       position: {
         x: Distance.meters(1),
         y: Distance.meters(0.91),
-        z: Distance.meters(1),
+        z: Distance.meters(1.5),
       }
     }),
     gravity: {
@@ -234,61 +234,61 @@ const canPositions: Vector3[] = [
   {
     x: Distance.centimeters(-22.7),
     y: Distance.centimeters(0),
-    z: Distance.centimeters(-14.8),
+    z: Distance.centimeters(35.2),
   },
   {
     x: Distance.centimeters(0),
     y: Distance.centimeters(0),
-    z: Distance.centimeters(-21.2),
+    z: Distance.centimeters(28.8),
   },
   {
     x: Distance.centimeters(16.2),
     y: Distance.centimeters(0),
-    z: Distance.centimeters(-24.3),
+    z: Distance.centimeters(25.7),
   },
   {
     x: Distance.centimeters(0),
     y: Distance.centimeters(0),
-    z: Distance.centimeters(-7.3),
+    z: Distance.centimeters(42.7),
   },
   {
     x: Distance.centimeters(-14.3),
     y: Distance.centimeters(0),
-    z: Distance.centimeters(6.9),
+    z: Distance.centimeters(56.9),
   },
   {
     x: Distance.centimeters(0),
     y: Distance.centimeters(0),
-    z: Distance.centimeters(7.2),
+    z: Distance.centimeters(57.2),
   },
   {
     x: Distance.centimeters(13.8),
     y: Distance.centimeters(0),
-    z: Distance.centimeters(6.9),
+    z: Distance.centimeters(56.9),
   },
   {
     x: Distance.centimeters(26),
     y: Distance.centimeters(0),
-    z: Distance.centimeters(15.5),
+    z: Distance.centimeters(65.5),
   },
   {
     x: Distance.centimeters(0),
     y: Distance.centimeters(0),
-    z: Distance.centimeters(35.4),
+    z: Distance.centimeters(85.4),
   },
   {
     x: Distance.centimeters(-19.3),
     y: Distance.centimeters(0),
-    z: Distance.centimeters(46.9),
+    z: Distance.centimeters(96.9),
   },
   {
     x: Distance.centimeters(0),
     y: Distance.centimeters(0),
-    z: Distance.centimeters(56.6),
+    z: Distance.centimeters(106.6),
   },
   {
     x: Distance.centimeters(19.2),
     y: Distance.centimeters(0),
-    z: Distance.centimeters(46.9),
+    z: Distance.centimeters(96.9),
   },
 ];

--- a/src/scenes/jbcSandboxA.ts
+++ b/src/scenes/jbcSandboxA.ts
@@ -32,7 +32,7 @@ export const JBC_Sandbox_A: Scene = {
         position: {
           x: Distance.centimeters(0),
           y: Distance.centimeters(5),
-          z: Distance.centimeters(17.5),
+          z: Distance.centimeters(67.5),
         },
         orientation: Rotation.AngleAxis.fromRaw({
           axis: { x: 1, y: 0, z: 0 },
@@ -50,7 +50,7 @@ export const JBC_Sandbox_A: Scene = {
         position: {
           x: Distance.centimeters(0),
           y: Distance.centimeters(5),
-          z: Distance.centimeters(-56.3),
+          z: Distance.centimeters(-6.3),
         },
         orientation: Rotation.AngleAxis.fromRaw({
           axis: { x: 1, y: 0, z: 0 },


### PR DESCRIPTION
PR #239 moved the origin to the center of the mat, so the robot's starting point for most scenes was (0, -50). This PR moves the origin back to the starting box so that the robot's starting point is (0, 0).

To avoid newly added objects from defaulting to the starting box, it also changes the default position for new objects to (0, 50), now the center of the mat.

In a future PR, we can support each scene having its own origin, since starting boxes can vary by scene/board.