### PR TITLE
Fix item visibility issues + Add Sandbox B

### DIFF
--- a/src/components/World/index.tsx
+++ b/src/components/World/index.tsx
@@ -245,10 +245,12 @@ class World_ extends React.PureComponent<Props & ReduxWorldProps, State> {
   };
 
   private onItemVisibilityChange_ = (id: string) => (visibility: boolean) => {
+    const originalNode = this.props.scene.referenceScene.nodes[id];
+
     this.props.onNodeChange(id, {
-      ...this.props.scene.workingScene.nodes[id],
+      ...originalNode,
       visible: visibility,
-    }, false, false);
+    }, true, false);
   };
 
   render() {

--- a/src/scenes/index.ts
+++ b/src/scenes/index.ts
@@ -1,4 +1,5 @@
 export * from './jbcSandboxA';
+export * from './jbcSandboxB';
 export * from './jbc1';
 export * from './jbc2';
 export * from './jbc2b';

--- a/src/scenes/jbcSandboxB.ts
+++ b/src/scenes/jbcSandboxB.ts
@@ -1,0 +1,11 @@
+import Scene from "../state/State/Scene";
+
+import { createBaseSceneSurfaceB } from './jbcBase';
+
+const baseScene = createBaseSceneSurfaceB();
+
+export const JBC_Sandbox_B: Scene = {
+  ...baseScene,
+  name: 'JBC Sandbox B',
+  description: `Junior Botball Challenge Sandbox on Mat B.`,
+};

--- a/src/state/State/Scene/Node.ts
+++ b/src/state/State/Scene/Node.ts
@@ -43,7 +43,7 @@ namespace Node {
     visible?: boolean;
   }
 
-  namespace Base {
+  export namespace Base {
     export const NIL: Base = {
       name: '',
       parentId: undefined,

--- a/src/state/reducer/scene.ts
+++ b/src/state/reducer/scene.ts
@@ -4,7 +4,7 @@ import Geometry from "../State/Scene/Geometry";
 import { ReferenceFrame } from "../../unit-math";
 import Camera from "../State/Scene/Camera";
 
-import { JBC_1 } from '../../scenes';
+import { JBC_Sandbox_A } from '../../scenes';
 import { ReferencedScenePair } from "..";
 
 export namespace SceneAction {
@@ -212,7 +212,7 @@ export type SceneAction = (
   SceneAction.SetCamera
 );
 
-export const reduceScene = (state: ReferencedScenePair = { referenceScene: JBC_1, workingScene: JBC_1 }, action: SceneAction): ReferencedScenePair => {
+export const reduceScene = (state: ReferencedScenePair = { referenceScene: JBC_Sandbox_A, workingScene: JBC_Sandbox_A }, action: SceneAction): ReferencedScenePair => {
   switch (action.type) {
     case 'replace-scene':
       return {

--- a/src/state/reducer/scenes.ts
+++ b/src/state/reducer/scenes.ts
@@ -82,6 +82,7 @@ export type ScenesAction = (
 const DEFAULT_SCENES: Scenes = {
   scenes: {
     jbcSandboxA: Async.loaded({ value: JBC_SCENES.JBC_Sandbox_A }),
+    jbcSandboxB: Async.loaded({ value: JBC_SCENES.JBC_Sandbox_B }),
     jbc1: Async.loaded({ value: JBC_SCENES.JBC_1 }),
     jbc2: Async.loaded({ value: JBC_SCENES.JBC_2 }),
     jbc2b: Async.loaded({ value: JBC_SCENES.JBC_2B }),


### PR DESCRIPTION
- Fix #369 by adding a sandbox scene for JBC Mat B
- Fix #370 by deleting physics impostors for invisible objects
- Fix #372 by making item visibility modify the reference scene, so that resetting the scene does not reset item visibilities
- Change the starting scene to JBC Sandbox A