### PR TITLE
Swap demobot motor ports

### DIFF
--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -355,8 +355,9 @@ export class Space implements Robotable {
       }
 
       // Update motor positions based on wheel rotation
-      const m0Position = currRobotState.motorPositions[0] + leftRotation * this.WHEEL_TICKS_PER_RADIAN;
-      const m3Position = currRobotState.motorPositions[3] + rightRotation * this.WHEEL_TICKS_PER_RADIAN;
+      const m3Position = currRobotState.motorPositions[3] + leftRotation * this.WHEEL_TICKS_PER_RADIAN;
+      const m0Position = currRobotState.motorPositions[0] + rightRotation * this.WHEEL_TICKS_PER_RADIAN;
+      
       store.dispatch(RobotStateAction.setRobotState({
         robotState: {
           ...currRobotState,

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -334,7 +334,7 @@ export class Space implements Robotable {
       const currRobotState = store.getState().robotState;
 
       // Set simulator motor speeds based on robot state
-      this.setDriveMotors(currRobotState.motorSpeeds[0], currRobotState.motorSpeeds[3]);
+      this.setDriveMotors(currRobotState.motorSpeeds[3], currRobotState.motorSpeeds[0]);
 
       // Set simulator servo positions based on robot state
       this.setServoPositions(currRobotState.servoPositions);

--- a/src/components/Layout/OverlayLayout.tsx
+++ b/src/components/Layout/OverlayLayout.tsx
@@ -318,6 +318,7 @@ export class OverlayLayout extends React.PureComponent<Props & ReduxOverlayLayou
       <Container style={style} className={className}>
         <SimulatorAreaContainer>
           <SimulatorArea
+            theme={theme}
             key='simulator'
             isSensorNoiseEnabled={settings.simulationSensorNoise}
             isRealisticSensorsEnabled={settings.simulationRealisticSensors}

--- a/src/components/Layout/SideLayout.tsx
+++ b/src/components/Layout/SideLayout.tsx
@@ -262,6 +262,7 @@ export class SideLayout extends React.PureComponent<Props & ReduxSideLayoutProps
 
     const simulator = <SimulatorAreaContainer>
       <SimulatorArea
+        theme={theme}
         key='simulator'
         isSensorNoiseEnabled={settings.simulationSensorNoise}
         isRealisticSensorsEnabled={settings.simulationRealisticSensors}

--- a/src/components/MotorsSwappedDialog.tsx
+++ b/src/components/MotorsSwappedDialog.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { styled } from 'styletron-react';
+import { State } from '../state';
+
+import { StyleProps } from "../style";
+import { Dialog } from './Dialog';
+import { Theme, ThemeProps } from "./theme";
+
+
+export interface MotorsSwappedDialogProps extends StyleProps {
+  theme: Theme;
+  onClose: () => void;
+}
+
+const Container = styled('div', ({ $theme }: { $theme: Theme }) => ({
+  padding: `${$theme.itemPadding * 2}px`,
+}));
+
+export default ({ style, className, theme, onClose }: MotorsSwappedDialogProps): JSX.Element => (
+  <Dialog name="Notice: Motor Ports Changed" onClose={onClose} theme={theme}>
+    <Container style={style} className={className} $theme={theme}>
+      Motor 0 is now the Demobot's right wheel. <br /> <br />
+      Motor 3 is now the Demobot's left wheel. <br /> <br />
+      This notice will not appear again.
+    </Container>
+  </Dialog>
+);

--- a/src/components/MotorsSwappedDialog.tsx
+++ b/src/components/MotorsSwappedDialog.tsx
@@ -22,6 +22,7 @@ export default ({ style, className, theme, onClose }: MotorsSwappedDialogProps):
     <Container style={style} className={className} $theme={theme}>
       Motor 0 is now the Demobot's right wheel. <br /> <br />
       Motor 3 is now the Demobot's left wheel. <br /> <br />
+      If you have an existing program using motors, you should swap motor ports 0 and 3. <br /> <br />
       This notice will not appear again.
     </Container>
   </Dialog>

--- a/src/components/SimulatorArea.tsx
+++ b/src/components/SimulatorArea.tsx
@@ -28,7 +28,7 @@ namespace ModalDialog {
   }
 
   export namespace MotorsSwapped {
-    /// Show until August 30th, 2022
+    // Show until August 30th, 2022
     export const SHOW_UNTIL: Date = new Date(2022, 7, 30);
 
     export const markShown = (shown: boolean) => {
@@ -41,7 +41,7 @@ namespace ModalDialog {
 
     export const hasShown = (): boolean => {
       try {
-        const shown = JSON.parse(window.localStorage.getItem('motors-swapped-dialog-shown'));
+        const shown: boolean = JSON.parse(window.localStorage.getItem('motors-swapped-dialog-shown')) as boolean;
         return shown;
       } catch (e) {
         return true;

--- a/src/components/SimulatorArea.tsx
+++ b/src/components/SimulatorArea.tsx
@@ -8,15 +8,67 @@ import resizeListener, { ResizeListener } from './ResizeListener';
 import { Vector2 } from '../math';
 
 import Loading from './Loading';
+import MotorsSwappedDialog from './MotorsSwappedDialog';
+import { Theme } from './theme';
+
+namespace ModalDialog {
+  export enum Type {
+    None,
+    MotorsSwapped
+  }
+
+  export interface None {
+    type: Type.None;
+  }
+
+  export const NONE: None = { type: Type.None };
+
+  export interface MotorsSwapped {
+    type: Type.MotorsSwapped;
+  }
+
+  export namespace MotorsSwapped {
+    /// Show until August 30th, 2022
+    export const SHOW_UNTIL: Date = new Date(2022, 7, 30);
+
+    export const markShown = (shown: boolean) => {
+      try {
+        window.localStorage.setItem('motors-swapped-dialog-shown', JSON.stringify(shown));
+      } catch (e) {
+        // ignore
+      }
+    };
+
+    export const hasShown = (): boolean => {
+      try {
+        const shown = JSON.parse(window.localStorage.getItem('motors-swapped-dialog-shown'));
+        return shown;
+      } catch (e) {
+        return true;
+      }
+    };
+
+    export const shouldShow = (): boolean => {
+      const now = new Date();
+      return now < SHOW_UNTIL && !hasShown();
+    };
+  }
+
+  export const MOTORS_SWAPPED: MotorsSwapped = { type: Type.MotorsSwapped };
+}
+
+type ModalDialog = ModalDialog.None | ModalDialog.MotorsSwapped;
 
 export interface SimulatorAreaProps {
+  theme: Theme;
   isSensorNoiseEnabled: boolean;
   isRealisticSensorsEnabled: boolean;
 }
 
 interface SimulatorAreaState {
-  loading: boolean,
-  loadingMessage: string
+  loading: boolean;
+  loadingMessage: string;
+  modalDialog: ModalDialog;
 }
 
 const Container = styled('div', {
@@ -42,6 +94,7 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps, Simulator
     this.state = { 
       loading: true,
       loadingMessage: '',
+      modalDialog: ModalDialog.NONE
     };
   }
 
@@ -66,7 +119,10 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps, Simulator
       .then(() => {
         this.setState({ 
           loading: false,
-          loadingMessage: ''
+          loadingMessage: '',
+          modalDialog: ModalDialog.MotorsSwapped.shouldShow()
+            ? ModalDialog.MOTORS_SWAPPED
+            : ModalDialog.NONE
         });
       })
       .catch(e => console.error('Simulator initialization failed', e));
@@ -114,13 +170,21 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps, Simulator
     }
   };
 
+  private onMotorsSwappedClose_ = (): void => {
+    ModalDialog.MotorsSwapped.markShown(true);
+    this.setState({ modalDialog: ModalDialog.NONE });
+  };
+
   render() {
-    if (this.state.loading) {
+    const { props, state } = this;
+    const { theme } = props;
+    const { modalDialog, loading, loadingMessage } = state;
+    if (loading) {
       return (
         <Container >
           <Loading 
             message='Initializing Simulator...'
-            errorMessage={this.state.loadingMessage}
+            errorMessage={loadingMessage}
           />
         </Container>
       );
@@ -128,6 +192,9 @@ export class SimulatorArea extends React.Component<SimulatorAreaProps, Simulator
     return (
       <Container ref={this.bindContainerRef_}>
         <Canvas ref={this.bindCanvasRef_} />
+        {modalDialog.type === ModalDialog.Type.MotorsSwapped && (
+          <MotorsSwappedDialog theme={theme} onClose={this.onMotorsSwappedClose_} />
+        )}
       </Container>
     );
   }


### PR DESCRIPTION
- Motor 0 is now the DemoBot's right wheel
- Motor 3 is now the DemoBot's left wheel
- A one-time dialog will appear notifying the user of the change. The dialog's shown status is stored in `localStorage`. The dialog will cease appearing altogether on August 30th, 2022, after which it can be removed from the code.