### PR TITLE
Don't swallow mouse events in GlobalEvents

### DIFF
--- a/src/util/GlobalEvents.ts
+++ b/src/util/GlobalEvents.ts
@@ -58,7 +58,7 @@ export namespace GlobalEvents {
         if (callback(event)) return true;
       }
 
-      return false;
+      return true;
     };
   }
 


### PR DESCRIPTION
Fix bug in `GlobalEvents` that caused all `mousemove` and `mouseup` events to be swallowed, not allowing the browser to perform default behaviors like text selection.

Fixes #249 