### PR TITLE
Close layout picker on outside click

### DIFF
--- a/src/components/Layout/LayoutPicker.tsx
+++ b/src/components/Layout/LayoutPicker.tsx
@@ -58,7 +58,9 @@ const Item = styled('div', (props: ThemeProps & ClickProps) => ({
   ':hover': !props.disabled && props.onClick ? {
     cursor: 'pointer',
     backgroundColor: `rgba(255, 255, 255, 0.1)`
-  } : {},
+  } : {
+    cursor: 'auto',
+  },
   userSelect: 'none',
   transition: 'background-color 0.2s, opacity 0.2s'
 }));

--- a/src/components/SimMenu.tsx
+++ b/src/components/SimMenu.tsx
@@ -124,10 +124,24 @@ class SimMenu extends React.PureComponent<Props, State> {
     };
   }
 
-  private onLayoutClick_ = () => {
+  private onLayoutClick_ = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    const layoutPickerNext = !this.state.layoutPicker;
     this.setState({
-      layoutPicker: !this.state.layoutPicker
+      layoutPicker: layoutPickerNext
     });
+
+    if (layoutPickerNext) {
+      window.addEventListener('click', this.onLayoutClickOutside_);
+    } else {
+      window.removeEventListener('click', this.onLayoutClickOutside_);
+    }
+
+    event.stopPropagation();
+  };
+
+  private onLayoutClickOutside_ = (event: MouseEvent) => {
+    this.setState({ layoutPicker: false });
+    window.removeEventListener('click', this.onLayoutClickOutside_);
   };
 
   render() {


### PR DESCRIPTION
Fixes #368 

Also fixes the cursor that's shown when hovering over non-buttons in the layout picker. Previously it showed a pointer