### PR TITLE
Add concurrency to staging workflow

### DIFF
--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -23,6 +23,8 @@ env:
   GKE_ZONE: us-central1-a
   IMAGE: kipr/simulator
 
+concurrency: ${{ github.workflow }}
+
 jobs:
   build-publish:
     name: Build and publish


### PR DESCRIPTION
Fixes #388 by using `concurrency` to limit the workflow to one run at a time

See the [GitHub Actions docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) for more info about `concurrency`