### PR TITLE
Prevent page overscroll

### DIFF
--- a/src/index.html.ejs
+++ b/src/index.html.ejs
@@ -14,6 +14,10 @@
       box-sizing: border-box;
     }
 
+    body {
+      overscroll-behavior: none;
+    }
+
     html, body {
       position: relative;
       margin: 0;


### PR DESCRIPTION
Prevent browser overflow behavior. `overscroll-behavior` is not yet supported in Safari, so this will only affect Chrome and Firefox. Safari 16 (currently in preview) will support `overscroll-behavior`.

Partially addresses #383 