### PR TITLE
Change registers to use `SharedArrayBuffer`

### DIFF
--- a/express.js
+++ b/express.js
@@ -184,14 +184,18 @@ app.use('/static', express.static(`${__dirname}/static`, {
   maxAge: config.caching.staticMaxAge,
 }));
 
-app.use('/dist', express.static(`${__dirname}/dist`));
+app.use('/dist', express.static(`${__dirname}/dist`, {
+  setHeaders: setCrossOriginIsolationHeaders,
+}));
 
 app.use(express.static(sourceDir, {
   maxAge: config.caching.staticMaxAge,
+  setHeaders: setCrossOriginIsolationHeaders,
 }));
 
 
 app.use('*', (req, res) => {
+  setCrossOriginIsolationHeaders(res);
   res.sendFile(`${__dirname}/${sourceDir}/index.html`);
 });
 
@@ -201,3 +205,9 @@ app.listen(config.server.port, () => {
   console.log(`Express web server started: http://localhost:${config.server.port}`);
   console.log(`Serving content from /${sourceDir}/`);
 });
+
+// Cross-origin isolation required for using features like SharedArrayBuffer
+function setCrossOriginIsolationHeaders(res) {
+  res.header("Cross-Origin-Opener-Policy", "same-origin");
+  res.header("Cross-Origin-Embedder-Policy", "require-corp");
+}

--- a/src/RegisterState.ts
+++ b/src/RegisterState.ts
@@ -4,6 +4,8 @@ export default {
   /* READ Only Registers ----------------------- */
   REG_R_START:  0,
 
+  // SHAREDARRAYBUFFER PADDING (1 BYTE)
+
   REG_R_VERSION_H:      1,
   REG_R_VERSION_L:      2,
 
@@ -32,6 +34,8 @@ export default {
   REG_RW_ADC_5_H:     21,
   REG_RW_ADC_5_L:     22,
   REG_RW_ADC_PE:      23,// low 6 bits used
+
+  // SHAREDARRAYBUFFER PADDING (1 BYTE)
 
   REG_RW_MAG_X_H:     24,
   REG_RW_MAG_X_L:     25,
@@ -124,6 +128,8 @@ export default {
   REG_RW_BUTTONS: 88,
 
   REG_READABLE_COUNT: 89,
+
+  // SHAREDARRAYBUFFER PADDING (1 BYTE)
 
 
 

--- a/src/SharedRegisters.ts
+++ b/src/SharedRegisters.ts
@@ -1,0 +1,86 @@
+import Registers from "./RegisterState";
+
+/**
+ * Represents the register data that is shared between the main thread and the worker thread.
+ * The data is stored in a SharedArrayBuffer and accessed using typed arrays and the appropriate
+ * atomic operations from Atomics.
+ * 
+ * The SharedArrayBuffer indexes and register address are not the same because the multi-byte
+ * array views must be aligned properly. For example, 4 byte values must start at address 0, 4, 8, etc.
+ * So there are some padding bytes throughout the register space to ensure alignment.
+ * 
+ * Additionally, the typed arrays use the platform's endianness (typically little-endian) while
+ * the multi-byte registers are stored in big-endian order. As a result, the indexes are also different
+ * within a multi-byte value, so the individual bytes in multi-byte values shouldn't be accessed separately.
+ */
+export default class SharedRegisters {
+  private readonly registerSharedArrayBuffer_: SharedArrayBuffer;
+
+  // Use typed arrays of various sizes to ensure atomic operations
+  private readonly registerArrayViewU8b_: Uint8Array;
+  private readonly registerArrayView8b_: Int8Array;
+  private readonly registerArrayViewU16b_: Uint16Array;
+  private readonly registerArrayView16b_: Int16Array;
+  private readonly registerArrayViewU32b_: Uint32Array;
+  private readonly registerArrayView32b_: Int32Array;
+
+  constructor(registerSharedArrayBuffer?: SharedArrayBuffer) {
+    // Add 3 bytes to account for padding. See RegisterState for which bytes are padded
+    this.registerSharedArrayBuffer_ = registerSharedArrayBuffer ?? new SharedArrayBuffer(Registers.REG_ALL_COUNT + 3);
+
+    this.registerArrayViewU8b_ = new Uint8Array(this.registerSharedArrayBuffer_);
+    this.registerArrayView8b_ = new Int8Array(this.registerSharedArrayBuffer_);
+    this.registerArrayViewU16b_ = new Uint16Array(this.registerSharedArrayBuffer_);
+    this.registerArrayView16b_ = new Int16Array(this.registerSharedArrayBuffer_);
+    this.registerArrayViewU32b_ = new Uint32Array(this.registerSharedArrayBuffer_);
+    this.registerArrayView32b_ = new Int32Array(this.registerSharedArrayBuffer_);
+  }
+
+  public getSharedArrayBuffer(): SharedArrayBuffer {
+    return this.registerSharedArrayBuffer_;
+  }
+
+  public setRegister8b(registerAddress: number, value: number) {
+    Atomics.store(this.registerArrayView8b_, SharedRegisters.getBufferIndexForRegisterAddress(registerAddress), value);
+  }
+
+  public setRegister16b(registerAddress: number, value: number) {
+    Atomics.store(this.registerArrayView16b_, SharedRegisters.getBufferIndexForRegisterAddress(registerAddress) / 2, value);
+  }
+
+  public setRegister32b(registerAddress: number, value: number) {
+    Atomics.store(this.registerArrayView32b_, SharedRegisters.getBufferIndexForRegisterAddress(registerAddress) / 4, value);
+  }
+
+  public incrementRegister32b(registerAddress: number, value: number) {
+    Atomics.add(this.registerArrayView32b_, SharedRegisters.getBufferIndexForRegisterAddress(registerAddress) / 4, value);
+  }
+
+  public getRegisterValue8b = (registerAddress: number, signed = false): number => {
+    const array = signed ? this.registerArrayView8b_ : this.registerArrayViewU8b_;
+    return Atomics.load(array, SharedRegisters.getBufferIndexForRegisterAddress(registerAddress));
+  };
+
+  public getRegisterValue16b = (registerAddress: number, signed = false): number => {
+    const array = signed ? this.registerArrayView16b_ : this.registerArrayViewU16b_;
+    return Atomics.load(array, SharedRegisters.getBufferIndexForRegisterAddress(registerAddress) / 2);
+  };
+
+  public getRegisterValue32b = (registerAddress: number, signed = false): number => {
+    const array = signed ? this.registerArrayView32b_ : this.registerArrayViewU32b_;
+    return Atomics.load(array, SharedRegisters.getBufferIndexForRegisterAddress(registerAddress) / 4);
+  };
+
+  /**
+   * Get the index in the SharedArrayBuffer that corresponds to the given address.
+   * Accounts for the padding bytes.
+   * @param address The address of the register.
+   * @returns The index in the SharedArrayBuffer that corresponds to the given address.
+   */
+  private static getBufferIndexForRegisterAddress = (address: number) => {
+    if (address <= Registers.REG_R_START) return address;
+    if (address <= Registers.REG_RW_ADC_PE) return address + 1;
+    if (address <= Registers.REG_RW_BUTTONS) return address + 2;
+    return address + 3;
+  };
+}

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -74,7 +74,7 @@ export class Space implements Robotable {
 
   // Fractional motor position accumulation
   private leftWheelPositionAccumulation_ = 0;
-  private rightWheelPositionAccumulation_= 0;
+  private rightWheelPositionAccumulation_ = 0;
 
   private sensorObjects_: SensorObject[] = [];
 

--- a/src/WorkerInstance.ts
+++ b/src/WorkerInstance.ts
@@ -34,7 +34,6 @@ class WorkerInstance {
   };
 
   public incrementMotorPositions = (motorPositionIncrements: [number, number, number, number]) => {
-    // TODO: Truncating the increment value will be lossy
     this.sharedRegister_.incrementRegister32b(Registers.REG_RW_MOT_0_B3, Math.trunc(motorPositionIncrements[0]) * 250);
     this.sharedRegister_.incrementRegister32b(Registers.REG_RW_MOT_1_B3, Math.trunc(motorPositionIncrements[1]) * 250);
     this.sharedRegister_.incrementRegister32b(Registers.REG_RW_MOT_2_B3, Math.trunc(motorPositionIncrements[2]) * 250);

--- a/src/WorkerProtocol.ts
+++ b/src/WorkerProtocol.ts
@@ -1,10 +1,5 @@
 export namespace Protocol {
   export namespace Worker {
-    export interface Register {
-      address: number;
-      value: number;
-    }
-    
     export interface StartRequest {
       type: 'start';
       code: string;
@@ -12,8 +7,7 @@ export namespace Protocol {
 
     export type Request = (
       StartRequest |
-      SetRegisterRequest |
-      ProgramEndedRequest |
+      SetSharedRegistersRequest |
       ProgramOutputRequest |
       ProgramErrorRequest |
       WorkerReadyRequest |
@@ -24,33 +18,12 @@ export namespace Protocol {
       type: 'start';
     }
 
-    export interface ProgramEndedRequest {
-      type: 'program-ended'
+    export type Response = StartResponse;
+
+    export interface SetSharedRegistersRequest {
+      type: 'setsharedregisters';
+      sharedArrayBuffer: SharedArrayBuffer;
     }
-
-    export interface ProgramEndedResponse {
-      type: 'program-ended'
-    }
-
-    export type Response = StartResponse | ProgramEndedResponse;
-
-
-    export interface SetRegisterRequest {
-      type: 'setregister';
-      registers: Register[];
-    }
-
-    export interface SetRegistersRequest {
-      type: 'setregisters';
-      // Layout: Address is in second byte, value in low byte ((address & 0x0F) << 8 | (value & 0xFF))
-      values: number[];
-    }
-
-    export interface SetRegistersResponse {
-      type: 'setregisters';
-    }
-
-    
 
     export interface ProgramOutputRequest {
       type: 'programoutput';
@@ -69,17 +42,6 @@ export namespace Protocol {
 
     export interface StoppedRequest {
       type: 'stopped'
-    }
-  }
-
-  export namespace Host {
-    export interface GetRegistersRequest {
-      type: 'get-registers'
-    }
-
-    export interface GetRegistersResponse {
-      type: 'get-registers';
-      values: number[];
     }
   }
 }

--- a/src/require.ts
+++ b/src/require.ts
@@ -1,5 +1,3 @@
-import Protocol from './WorkerProtocol';
-
 export interface EmscriptenModule {
   context: ModuleContext,
   print: (s: string) => void,
@@ -9,8 +7,12 @@ export interface EmscriptenModule {
 }
 
 export interface ModuleContext {
-  registers?: Array<number>,
-  onRegistersChange?: (registers: Protocol.Worker.Register[]) => void,
+  setRegister8b?: (address: number, value: number) => void,
+  setRegister16b?: (address: number, value: number) => void,
+  setRegister32b?: (address: number, value: number) => void,
+  readRegister8b?: (address: number) => number,
+  readRegister16b?: (address: number) => number,
+  readRegister32b?: (address: number) => number,
   onStop?: () => void;
 }
 

--- a/src/state/reducer/robotState.ts
+++ b/src/state/reducer/robotState.ts
@@ -1,4 +1,5 @@
 import { RobotState } from "../../RobotState";
+import WorkerInstance from "../../WorkerInstance";
 
 export namespace RobotStateAction {
   export interface SetRobotState {
@@ -12,16 +13,63 @@ export namespace RobotStateAction {
     type: 'set-robot-state',
     ...params,
   });
+  export interface SetRobotSensorValues {
+    type: 'set-robot-sensor-values';
+    analogValues: RobotState.AnalogValues;
+    digitalValues: RobotState.DigitalValues;
+  }
+
+  export type SetRobotSensorValuesParams = Omit<SetRobotSensorValues, 'type'>;
+
+  export const setRobotSensorValues = (params: SetRobotSensorValuesParams): SetRobotSensorValues => ({
+    type: 'set-robot-sensor-values',
+    ...params,
+  });
+
+  export interface IncrementRobotMotorPositions {
+    type: 'increment-robot-motor-positions';
+    motorPositions: [number, number, number, number];
+  }
+
+  export type IncrementRobotMotorPositionsParams = Omit<IncrementRobotMotorPositions, 'type'>;
+
+  export const incrementRobotMotorPositions = (params: IncrementRobotMotorPositionsParams): IncrementRobotMotorPositions => ({
+    type: 'increment-robot-motor-positions',
+    ...params,
+  });
 }
 
 export type RobotStateAction = (
-  RobotStateAction.SetRobotState
+  RobotStateAction.SetRobotState |
+  RobotStateAction.SetRobotSensorValues |
+  RobotStateAction.IncrementRobotMotorPositions
 );
 
 export const reduceRobotState = (state: RobotState = RobotState.empty, action: RobotStateAction): RobotState => {
   switch (action.type) {
     case 'set-robot-state':
       return action.robotState;
+    case 'set-robot-sensor-values':
+      // Update registers to keep them in sync with state changes
+      WorkerInstance.setSensorValues(action.analogValues, action.digitalValues);
+      return {
+        ...state,
+        analogValues: action.analogValues,
+        digitalValues: action.digitalValues,
+      };
+    case 'increment-robot-motor-positions': {
+      // Update registers to keep them in sync with state changes
+      WorkerInstance.incrementMotorPositions(action.motorPositions);
+      return {
+        ...state,
+        motorPositions: [
+          state.motorPositions[0] + action.motorPositions[0],
+          state.motorPositions[1] + action.motorPositions[1],
+          state.motorPositions[2] + action.motorPositions[2],
+          state.motorPositions[3] + action.motorPositions[3],
+        ],
+      };
+    }
     default:
       return state;
   }


### PR DESCRIPTION
(draft PR, do not merge until corresponding libwallaby change is merged)

Instead of rapidly posting messages back and forth, use `SharedArrayBuffer` to share registers between the simulator and user program. This helps fix/avoid synchronization bugs (fixes #86) and completely removes the rapid `postMessage()` calls that currently happen (fixes #20)