### PR TITLE
Emscripten fs command buffers

### DIFF
--- a/src/python/registersDevice.ts
+++ b/src/python/registersDevice.ts
@@ -75,6 +75,86 @@ export default (params: RegistersDeviceParams): FsDevice => {
             }
             break;
           }
+          // REQUEST_READ_MASK
+          case 2: {
+            switch (size) {
+              case 1: {
+                outBuffer.push(registers.getRegisterValue8b(address) & uBuffer[offset + i + 0]);
+                i += 1;
+                break;
+              }
+              case 2: {
+                const value = registers.getRegisterValue16b(address);
+                outBuffer.push(((value & 0xFF00) >> 8) & uBuffer[offset + i + 0]);
+                outBuffer.push(((value & 0x00FF) >> 0) & uBuffer[offset + i + 1]);
+                i += 2;
+                break;
+              }
+              case 4: {
+                const value = registers.getRegisterValue32b(address);
+                outBuffer.push(((value & 0xFF000000) >> 24) & uBuffer[offset + i + 0]);
+                outBuffer.push(((value & 0x00FF0000) >> 16) & uBuffer[offset + i + 1]);
+                outBuffer.push(((value & 0x0000FF00) >> 8) & uBuffer[offset + i + 2]);
+                outBuffer.push(((value & 0x000000FF) >> 0) & uBuffer[offset + i + 3]);
+                i += 4;
+                break;
+              }
+            }
+            break;
+          }
+          // REQUEST_WRITE_MASK
+          case 3: {
+            switch (size) {
+              case 1: {
+                const mask = uBuffer[offset + i + 1];
+                
+                let value = registers.getRegisterValue8b(address) & ~mask;
+                value |= uBuffer[offset + i + 0] & mask;
+                
+                registers.setRegister8b(address, value);
+                i += 2;
+                break;
+              }
+              case 2: {
+                const mask = (
+                  (uBuffer[offset + i + 2] << 8) |
+                  (uBuffer[offset + i + 3] << 0)
+                );
+
+                let value = registers.getRegisterValue16b(address) & ~mask;
+                value |= (
+                  (uBuffer[offset + i + 0] << 8) |
+                  (uBuffer[offset + i + 1] << 0)
+                ) & mask;
+                
+                registers.setRegister16b(address, value);
+
+                i += 4;
+                break;
+              }
+              case 4: {
+                const mask = (
+                  (uBuffer[offset + i + 4] << 24) |
+                  (uBuffer[offset + i + 5] << 16) |
+                  (uBuffer[offset + i + 6] << 8) |
+                  (uBuffer[offset + i + 7] << 0)
+                );
+
+                let value = registers.getRegisterValue32b(address) & ~mask;
+                value |= (
+                  (uBuffer[offset + i + 0] << 24) |
+                  (uBuffer[offset + i + 1] << 16) |
+                  (uBuffer[offset + i + 2] << 8) |
+                  (uBuffer[offset + i + 3] << 0)
+                ) & mask;
+
+                registers.setRegister32b(address, value);
+                i += 8;
+                break;
+              }
+            }
+            break;
+          }
           default: {
             throw new Error(`Unknown request type: ${requestType}`);
           }


### PR DESCRIPTION
This PR adds support for libwallaby command buffers to the `registersDevice` used by the python backend.