### PR TITLE
Fix race condition during program stop

### DIFF
--- a/express.js
+++ b/express.js
@@ -85,7 +85,7 @@ if (config.server.dependencies.libkipr_c && config.server.dependencies.emsdk_env
       env['EMSDK'] = config.server.dependencies.emsdk_env.EMSDK;
       env['EM_CONFIG'] = config.server.dependencies.emsdk_env.EM_CONFIG;
   
-      exec(`emcc -s WASM=0 -s INVOKE_RUN=0 -s ASYNCIFY -s EXIT_RUNTIME=1 -s "EXPORTED_FUNCTIONS=['_main', '_simMainWrapper']" -I${config.server.dependencies.libkipr_c}/include -L${config.server.dependencies.libkipr_c}/lib -lkipr -o ${path}.js ${path}`, {
+      exec(`emcc -s WASM=0 -s INVOKE_RUN=0 -s EXIT_RUNTIME=1 -s "EXPORTED_FUNCTIONS=['_main', '_simMainWrapper']" -I${config.server.dependencies.libkipr_c}/include -L${config.server.dependencies.libkipr_c}/lib -lkipr -o ${path}.js ${path}`, {
         env
       }, (err, stdout, stderr) => {
         if (err) {

--- a/src/SharedRegisters.ts
+++ b/src/SharedRegisters.ts
@@ -40,6 +40,12 @@ export default class SharedRegisters {
     return this.registerSharedArrayBuffer_;
   }
 
+  public clone(): SharedRegisters {
+    const newRegisterSharedArrayBuffer = new SharedArrayBuffer(this.registerSharedArrayBuffer_.byteLength);
+    new Uint8Array(newRegisterSharedArrayBuffer).set(this.registerArrayViewU8b_);
+    return new SharedRegisters(newRegisterSharedArrayBuffer);
+  }
+
   public setRegister8b(registerAddress: number, value: number) {
     Atomics.store(this.registerArrayView8b_, SharedRegisters.getBufferIndexForRegisterAddress(registerAddress), value);
   }

--- a/src/WorkerInstance.ts
+++ b/src/WorkerInstance.ts
@@ -16,7 +16,7 @@ class WorkerInstance {
   
   onStopped: () => void;
 
-  private readonly sharedRegister_ = new SharedRegisters();
+  private sharedRegister_ = new SharedRegisters();
 
   private onStopped_ = () => {
     // Reset specific registers to stop motors and disable servos
@@ -162,11 +162,11 @@ class WorkerInstance {
   }
 
   stop() {
+    // Recreate a new set of registers to cut off any communication with the worker
+    this.sharedRegister_ = this.sharedRegister_.clone();
     this.worker_.terminate();
 
-    // Reset specific registers to stop motors and disable servos
-    this.sharedRegister_.setRegister8b(Registers.REG_RW_MOT_MODES, 0x00);
-    this.sharedRegister_.setRegister8b(Registers.REG_RW_MOT_SRV_ALLSTOP, 0xF0);
+    this.onStopped_();
 
     this.startWorker();
   }

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -380,9 +380,6 @@ export class Root extends React.Component<Props, State> {
 
   private onStopClick_ = () => {
     WorkerInstance.stop();
-    this.setState({
-      simulatorState: SimulatorState.STOPPED
-    });
   };
 
   private onDownloadClick_ = () => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -57,8 +57,6 @@ const startC = (message: Protocol.Worker.StartRequest) => {
   printErr
   );
 
-  console.log(mod);
-
   mod.onRuntimeInitialized = () => {
     try {
       mod._simMainWrapper();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -32,6 +32,16 @@ namespace ExitStatusError {
 }
 
 const startC = (message: Protocol.Worker.StartRequest) => {
+  let stoppedSent = false;
+
+  const sendStopped = () => {
+    if (stoppedSent) return;
+    ctx.postMessage({
+      type: 'stopped',
+    } as Protocol.Worker.StoppedRequest);
+    stoppedSent = true;
+  };
+
   const mod = dynRequire(message.code, {
     setRegister8b: (address: number, value: number) => sharedRegister_.setRegister8b(address, value),
     setRegister16b: (address: number, value: number) => sharedRegister_.setRegister16b(address, value),
@@ -39,11 +49,7 @@ const startC = (message: Protocol.Worker.StartRequest) => {
     readRegister8b: (address: number) => sharedRegister_.getRegisterValue8b(address),
     readRegister16b: (address: number) => sharedRegister_.getRegisterValue16b(address),
     readRegister32b: (address: number) => sharedRegister_.getRegisterValue32b(address),
-    onStop: () => {
-      ctx.postMessage({
-        type: 'stopped',
-      } as Protocol.Worker.StoppedRequest);
-    },
+    onStop: sendStopped
   },
   print,
   printErr
@@ -63,9 +69,7 @@ const startC = (message: Protocol.Worker.StartRequest) => {
         }
       }
 
-      ctx.postMessage({
-        type: 'stopped',
-      } as Protocol.Worker.StoppedRequest);
+      sendStopped();
     }
   };
 


### PR DESCRIPTION
Currently, the user program can continue writing to the `SharedArrayBuffer` for some time after `terminate()` is called on the worker, creating a race condition with cleanup logic.

This PR recreates the register `SharedArrayBuffer` when the program is stopped, effectively cutting off communication with the worker