### PR TITLE
Separate login to a non-isolated page + Popup auth

### DIFF
--- a/configs/webpack/common.js
+++ b/configs/webpack/common.js
@@ -16,6 +16,7 @@ try {
 module.exports = {
   entry: {
     app: './index.tsx',
+    login: './login/index.tsx',
     'editor.worker': 'monaco-editor/esm/vs/editor/editor.worker.js'
   },
   output: {
@@ -112,7 +113,8 @@ module.exports = {
     ],
   },
   plugins: [
-    new HtmlWebpackPlugin({ template: 'index.html.ejs', }),
+    new HtmlWebpackPlugin({ template: 'index.html.ejs', excludeChunks: ['login'] }),
+    new HtmlWebpackPlugin({ template: 'login/login.html.ejs', filename: 'login.html', chunks: ['login'] }),
     new DefinePlugin({
       SIMULATOR_VERSION: JSON.stringify(require('../../package.json').version),
       SIMULATOR_GIT_HASH: JSON.stringify(commitHash),

--- a/express.js
+++ b/express.js
@@ -228,6 +228,10 @@ app.use(express.static(sourceDir, {
   setHeaders: setCrossOriginIsolationHeaders,
 }));
 
+app.get('/login', (req, res) => {
+  res.sendFile(`${__dirname}/${sourceDir}/login.html`);
+});
+
 
 app.use('*', (req, res) => {
   setCrossOriginIsolationHeaders(res);

--- a/src/PageRouter.tsx
+++ b/src/PageRouter.tsx
@@ -1,13 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-
 import * as React from 'react';
 import { BrowserRouter as Router, Switch, Route, RouteComponentProps } from 'react-router-dom';
 import { auth } from './firebase/firebase';
 import routes from './pages/routes';
 import AuthRoute from './firebase/modules/auth/AuthRoute';
-import { getRedirectResult } from '@firebase/auth';
 
 import Loading from './components/Loading';
 
@@ -27,8 +22,8 @@ const PageRouter: React.FunctionComponent<PageRouterProps> = props => {
       setLoading(false);
     });
   }, []);
+
   if (loading) {
-    // const result = getRedirectResult(auth);
     return <Loading />;
   }
 
@@ -42,7 +37,6 @@ const PageRouter: React.FunctionComponent<PageRouterProps> = props => {
             exact={route.exact}
             render={(routeProps: RouteComponentProps) => {
               if (route.protected) return <AuthRoute ><route.component {...routeProps} /></AuthRoute>;
-              if (route.index !== undefined) return <route.component {...routeProps} externalIndex={route.index} />;
               return <route.component  {...routeProps} />;
             }}
           />)}

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -1,8 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
 import { initializeApp } from 'firebase/app';
-import { GoogleAuthProvider, getAuth, getRedirectResult } from 'firebase/auth';
+import { GoogleAuthProvider, getAuth } from 'firebase/auth';
 import config from './config';
 
 const Firebase = initializeApp(config.firebase);

--- a/src/firebase/modules/auth/AuthRoute.tsx
+++ b/src/firebase/modules/auth/AuthRoute.tsx
@@ -10,9 +10,9 @@ const AuthRoute: React.FunctionComponent<IAuthRouteProps> = props => {
   const { children } = props;
 
   // auth.currentUser provides the firebase.User object if authenticated. 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   if (!auth.currentUser) {
-    return <Redirect to="/" />;
+    window.location.href = '/login';
+    return null;
   }
   return (
     <div>{children}</div>

--- a/src/firebase/modules/auth/AuthRoute.tsx
+++ b/src/firebase/modules/auth/AuthRoute.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Redirect } from 'react-router-dom';
 import { auth } from '../../firebase';
+
 interface IAuthRouteProps {
   children: React.ReactNode;
   // any other props that come into the component
@@ -14,6 +14,7 @@ const AuthRoute: React.FunctionComponent<IAuthRouteProps> = props => {
     window.location.href = '/login';
     return null;
   }
+  
   return (
     <div>{children}</div>
   );

--- a/src/login/LoginPage.tsx
+++ b/src/login/LoginPage.tsx
@@ -222,7 +222,7 @@ class LoginPage extends React.Component<Props, State> {
 
   private signInWithSocialMedia_ = async (provider: AuthProvider) => {
     this.setState({ authenticating: true });
-    await signInWithRedirect(auth, provider);
+    await signInWithPopup(auth, provider);
   };
 
   private onTabIndexChange_ = (index: number) => {

--- a/src/login/LoginPage.tsx
+++ b/src/login/LoginPage.tsx
@@ -8,7 +8,7 @@ import {
   createUserWithEmail, 
   forgotPassword
 } from '../firebase/modules/auth';
-import { AuthProvider, getRedirectResult, signInWithRedirect } from 'firebase/auth';
+import { AuthProvider, getRedirectResult, signInWithPopup, signInWithRedirect } from 'firebase/auth';
 import Form from '../components/Form';
 import { TabBar } from '../components/TabBar';
 

--- a/src/login/index.tsx
+++ b/src/login/index.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import * as ReactDom from 'react-dom';
+import { DARK } from '../components/theme';
+import LoginPage from './LoginPage';
+
+import { Provider as StyletronProvider } from "styletron-react";
+import { Client as Styletron } from "styletron-engine-atomic";
+
+const reactRoot = document.getElementById('reactRoot');
+
+const engine = new Styletron({ prefix: 'style' });
+
+ReactDom.render(
+  <StyletronProvider value={engine} debugAfterHydration>
+    <LoginPage theme={DARK} />
+  </StyletronProvider>,
+  reactRoot
+);

--- a/src/login/login.html.ejs
+++ b/src/login/login.html.ejs
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <link rel="icon" type="image/x-icon" href="/static/favicon.png">
+  <title>KISS IDE Simulator</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+  <link href="/static/fontawesome-free-5.15.3-web/css/all.min.css" rel="stylesheet">
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      overscroll-behavior: none;
+    }
+
+    html, body {
+      position: relative;
+      margin: 0;
+      padding: 0;
+      background-color: #dcdde1;
+      
+      font-family: 'Roboto', sans-serif;
+      font-weight: 300;
+    }
+  </style>
+</head>
+<body>
+  <div id="reactRoot"></div>
+</body>
+</html>

--- a/src/pages/interfaces/page.interface.ts
+++ b/src/pages/interfaces/page.interface.ts
@@ -1,3 +1,0 @@
-export default interface PageProps {
-  externalIndex?: number;
-}

--- a/src/pages/interfaces/route.interface.ts
+++ b/src/pages/interfaces/route.interface.ts
@@ -1,8 +1,9 @@
+import React from "react";
+
 export default interface IRoute {
   path: string;
   exact: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  component: any;
+  component: typeof React.Component;
   name: string; // Used to update page infon and title. 
   protected: boolean; // This will defines if the route is proteted or not
 }

--- a/src/pages/interfaces/route.interface.ts
+++ b/src/pages/interfaces/route.interface.ts
@@ -3,7 +3,6 @@ export default interface IRoute {
   exact: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   component: any;
-  index?: number;
   name: string; // Used to update page infon and title. 
   protected: boolean; // This will defines if the route is proteted or not
 }

--- a/src/pages/routes.ts
+++ b/src/pages/routes.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import IRoute from "./interfaces/route.interface";
 import Dashboard from "./Dashboard";
 import { Root } from '../components/Root';

--- a/src/pages/routes.ts
+++ b/src/pages/routes.ts
@@ -2,24 +2,15 @@
 import IRoute from "./interfaces/route.interface";
 import Dashboard from "./Dashboard";
 import { Root } from '../components/Root';
-import HomePage from "./HomePage";
 import Tutorials from "./Tutorials";
 
 const routes: IRoute[] = [
   {
     path: '/',
     exact: true,
-    component: HomePage,
+    component: Dashboard,
     name: 'Home Page',
-    protected: false
-  },
-  {
-    path: '/signup',
-    exact: false,
-    component: HomePage,
-    index: 1,
-    name: 'Home Page',
-    protected: false
+    protected: true
   },
   {
     path: '/dashboard',


### PR DESCRIPTION
Firebase login can't work in a cross-origin isolated context, so the login page needs to be served separately from the main page. The backend does not send the isolation headers for the login page.

Also change Google sign-in to use popup flow instead of redirect flow. This is required for Firefox due to partitioned storage. For details, see:
- https://developer.mozilla.org/en-US/docs/Web/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign
- https://blog.mozilla.org/en/products/firefox/firefox-rolls-out-total-cookie-protection-by-default-to-all-users-worldwide/