### PR TITLE
Reduce bundle sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "simulator",
   "version": "1.2.0",
+  "sideEffects": false,
   "main": "dist/index.js",
   "author": "KISS Institute for Practical Robotics",
   "license": "GPL-3.0-only",
@@ -38,9 +39,9 @@
     "webpack-merge": "^5.7.3"
   },
   "dependencies": {
+    "@babylonjs/core": "^4.2.0",
+    "@babylonjs/loaders": "^4.2.0",
     "@types/react": "^16.9.25",
-    "babylonjs": "^4.2.0",
-    "babylonjs-loaders": "^4.2.0",
     "body-parser": "^1.19.0",
     "css-loader": "^3.5.3",
     "discord.js": "^13.6.0",

--- a/src/math.ts
+++ b/src/math.ts
@@ -1,4 +1,4 @@
-import * as Babylon from 'babylonjs';
+import { Vector3 as BabylonVector3, Quaternion as BabylonQuaternion } from '@babylonjs/core/Maths/math.vector';
 
 export interface Vector2 {
   x: number;
@@ -99,8 +99,8 @@ export namespace Vector3 {
   });
   export const length = (vec: Vector3): number => Math.sqrt(Math.pow(vec.x, 2) + Math.pow(vec.y, 2) + Math.pow(vec.z, 2));
 
-  export const toBabylon = (vec: Vector3): Babylon.Vector3 => new Babylon.Vector3(vec.x, vec.y, vec.z);
-  export const fromBabylon = (vec: Babylon.Vector3): Vector3 => ({ x: vec.x, y: vec.y, z: vec.z });
+  export const toBabylon = (vec: Vector3): BabylonVector3 => new BabylonVector3(vec.x, vec.y, vec.z);
+  export const fromBabylon = (vec: BabylonVector3): Vector3 => ({ x: vec.x, y: vec.y, z: vec.z });
 
   export const distance = (lhs: Vector3, rhs: Vector3): number => Math.sqrt(Math.pow(rhs.x - lhs.x, 2) + Math.pow(rhs.y - lhs.y, 2) + Math.pow(rhs.z - lhs.z, 2));
 }
@@ -121,13 +121,13 @@ export namespace Euler {
 
   export const fromQuaternion = (q: Quaternion): Euler => {
     // I'm cheating here... FIXME.
-    const q1 = new Babylon.Quaternion(q.x, q.y, q.z, q.w);
+    const q1 = new BabylonQuaternion(q.x, q.y, q.z, q.w);
     const e = q1.toEulerAngles();
     return { x: e.x, y: e.y, z: e.z, order: 'yzx' };
   };
 
   export const toQuaternion = (euler: Euler): Quaternion => {
-    return Quaternion.fromBabylon(Babylon.Quaternion.FromEulerAngles(euler.x, euler.y, euler.z));
+    return Quaternion.fromBabylon(BabylonQuaternion.FromEulerAngles(euler.x, euler.y, euler.z));
   };
 }
 
@@ -210,8 +210,8 @@ export namespace Quaternion {
     };
   };
 
-  export const toBabylon = (quat: Quaternion): Babylon.Quaternion => new Babylon.Quaternion(quat.x, quat.y, quat.z, quat.w);
-  export const fromBabylon = (quat: Babylon.Quaternion): Quaternion => ({
+  export const toBabylon = (quat: Quaternion): BabylonQuaternion => new BabylonQuaternion(quat.x, quat.y, quat.z, quat.w);
+  export const fromBabylon = (quat: BabylonQuaternion): Quaternion => ({
     x: quat.x,
     y: quat.y,
     z: quat.z,
@@ -229,7 +229,7 @@ export namespace Quaternion {
 
   export const slerp = (lhs: Quaternion, rhs: Quaternion, t: number): Quaternion => {
     // We're going to cheat
-    const q = Babylon.Quaternion.Slerp(toBabylon(lhs), toBabylon(rhs), t);
+    const q = BabylonQuaternion.Slerp(toBabylon(lhs), toBabylon(rhs), t);
     return fromBabylon(q);
   };
 

--- a/src/sensors/EtSensor.ts
+++ b/src/sensors/EtSensor.ts
@@ -1,17 +1,22 @@
-import * as Babylon from 'babylonjs';
+import { Ray as BabylonRay } from '@babylonjs/core/Culling/ray';
+import { Vector3 as BabylonVector3 } from '@babylonjs/core/Maths/math.vector';
+import { AbstractMesh as BabylonAbstractMesh } from '@babylonjs/core/Meshes/abstractMesh';
+import { LinesBuilder as BabylonLinesBuilder } from '@babylonjs/core/Meshes/Builders/linesBuilder';
+import { LinesMesh as BabylonLinesMesh } from '@babylonjs/core/Meshes/linesMesh';
+
 import Sensor from './Sensor';
 import SensorObject from './SensorObject';
 
-const vecToLocal = (vector: Babylon.Vector3, mesh: Babylon.AbstractMesh): Babylon.Vector3 => {
+const vecToLocal = (vector: BabylonVector3, mesh: BabylonAbstractMesh): BabylonVector3 => {
   const matrix = mesh.getWorldMatrix();
-  return Babylon.Vector3.TransformCoordinates(vector, matrix);
+  return BabylonVector3.TransformCoordinates(vector, matrix);
 };
 
 export class EtSensor implements SensorObject {
   private config_: SensorObject.Config<Sensor.Et>;
 
-  private ray: Babylon.Ray;
-  private visualMesh: Babylon.LinesMesh;
+  private ray: BabylonRay;
+  private visualMesh: BabylonLinesMesh;
 
   private sinceLastUpdate = 0;
   
@@ -28,11 +33,11 @@ export class EtSensor implements SensorObject {
     const sensor = Sensor.Et.fill(config.sensor);
     this.config_ = { ...config, sensor };
 
-    this.ray = new Babylon.Ray(Babylon.Vector3.Zero(), Babylon.Vector3.Zero(), this.config_.sensor.maxRange);
-    this.visualMesh = Babylon.MeshBuilder.CreateLines(
+    this.ray = new BabylonRay(BabylonVector3.Zero(), BabylonVector3.Zero(), this.config_.sensor.maxRange);
+    this.visualMesh = BabylonLinesBuilder.CreateLines(
       this.VISUAL_MESH_NAME,
       {
-        points: [Babylon.Vector3.Zero(), Babylon.Vector3.Zero()],
+        points: [BabylonVector3.Zero(), BabylonVector3.Zero()],
         updatable: true,
       },
       this.config_.scene
@@ -55,7 +60,7 @@ export class EtSensor implements SensorObject {
     const originPoint = vecToLocal(this.config_.sensor.origin, this.config_.mesh);
 
     let forwardDirection = forwardPoint.subtract(this.config_.mesh.absolutePosition);
-    forwardDirection = Babylon.Vector3.Normalize(forwardDirection);
+    forwardDirection = BabylonVector3.Normalize(forwardDirection);
     
     this.ray.origin = originPoint;
     this.ray.direction = forwardDirection;
@@ -75,7 +80,7 @@ export class EtSensor implements SensorObject {
     if (!this.isVisible) return false;
 
     const newLinePoints = [this.ray.origin, this.ray.origin.add(this.ray.direction.scale(this.ray.length))];
-    this.visualMesh = Babylon.MeshBuilder.CreateLines(this.VISUAL_MESH_NAME, { points: newLinePoints, instance: this.visualMesh }, this.config_.scene);
+    this.visualMesh = BabylonLinesBuilder.CreateLines(this.VISUAL_MESH_NAME, { points: newLinePoints, instance: this.visualMesh }, this.config_.scene);
     
     return true;
   }

--- a/src/sensors/IrSensor.ts
+++ b/src/sensors/IrSensor.ts
@@ -1,17 +1,22 @@
-import * as Babylon from 'babylonjs';
+import { Ray as BabylonRay } from '@babylonjs/core/Culling/ray';
+import { Vector3 as BabylonVector3 } from '@babylonjs/core/Maths/math.vector';
+import { AbstractMesh as BabylonAbstractMesh } from '@babylonjs/core/Meshes/abstractMesh';
+import { LinesBuilder as BabylonLinesBuilder } from '@babylonjs/core/Meshes/Builders/linesBuilder';
+import { LinesMesh as BabylonLinesMesh } from '@babylonjs/core/Meshes/linesMesh';
+
 import Sensor from './Sensor';
 import SensorObject from './SensorObject';
 
-const vecToLocal = (vector: Babylon.Vector3, mesh: Babylon.AbstractMesh): Babylon.Vector3 => {
+const vecToLocal = (vector: BabylonVector3, mesh: BabylonAbstractMesh): BabylonVector3 => {
   const matrix = mesh.getWorldMatrix();
-  return Babylon.Vector3.TransformCoordinates(vector, matrix);
+  return BabylonVector3.TransformCoordinates(vector, matrix);
 };
 
 export class IrSensor implements SensorObject {
   private config_: SensorObject.Config<Sensor.Ir>;
 
-  private ray: Babylon.Ray;
-  private visualMesh: Babylon.LinesMesh;
+  private ray: BabylonRay;
+  private visualMesh: BabylonLinesMesh;
 
   private sinceLastUpdate = 0;
   
@@ -31,11 +36,11 @@ export class IrSensor implements SensorObject {
     const sensor = Sensor.Ir.fill(config.sensor);
     this.config_ = { ...config, sensor };
 
-    this.ray = new Babylon.Ray(Babylon.Vector3.Zero(), Babylon.Vector3.Zero(), this.config_.sensor.maxRange);
-    this.visualMesh = Babylon.MeshBuilder.CreateLines(
+    this.ray = new BabylonRay(BabylonVector3.Zero(), BabylonVector3.Zero(), this.config_.sensor.maxRange);
+    this.visualMesh = BabylonLinesBuilder.CreateLines(
       this.VISUAL_MESH_NAME,
       {
-        points: [Babylon.Vector3.Zero(), Babylon.Vector3.Zero()],
+        points: [BabylonVector3.Zero(), BabylonVector3.Zero()],
         updatable: true,
       },
       this.config_.scene
@@ -58,7 +63,7 @@ export class IrSensor implements SensorObject {
     const originPoint = vecToLocal(this.config_.sensor.origin, this.config_.mesh);
 
     let forwardDirection = forwardPoint.subtract(this.config_.mesh.absolutePosition);
-    forwardDirection = Babylon.Vector3.Normalize(forwardDirection);
+    forwardDirection = BabylonVector3.Normalize(forwardDirection);
     
     this.ray.origin = originPoint;
     this.ray.direction = forwardDirection;
@@ -111,7 +116,7 @@ export class IrSensor implements SensorObject {
     if (!this.isVisible) return false;
 
     const newLinePoints = [this.ray.origin, this.ray.origin.add(this.ray.direction.scale(this.ray.length))];
-    this.visualMesh = Babylon.MeshBuilder.CreateLines(this.VISUAL_MESH_NAME, { points: newLinePoints, instance: this.visualMesh }, this.config_.scene);
+    this.visualMesh = BabylonLinesBuilder.CreateLines(this.VISUAL_MESH_NAME, { points: newLinePoints, instance: this.visualMesh }, this.config_.scene);
     
     return true;
   }

--- a/src/sensors/Sensor.ts
+++ b/src/sensors/Sensor.ts
@@ -1,4 +1,4 @@
-import * as Babylon from 'babylonjs';
+import { Vector3 as BabylonVector3 } from '@babylonjs/core/Maths/math.vector';
 
 namespace Sensor {
   export namespace Output {
@@ -72,8 +72,8 @@ namespace Sensor {
 
   export interface Et extends Common {
     type: Type.Et;
-    forward: Babylon.Vector3;
-    origin: Babylon.Vector3;
+    forward: BabylonVector3;
+    origin: BabylonVector3;
     maxRange?: number;
     noiseRadius?: number;
   }
@@ -88,8 +88,8 @@ namespace Sensor {
 
   export interface Ir extends Common {
     type: Type.Ir;
-    forward: Babylon.Vector3;
-    origin: Babylon.Vector3;
+    forward: BabylonVector3;
+    origin: BabylonVector3;
     maxRange?: number;
     noiseRadius?: number;
   }

--- a/src/sensors/SensorObject.ts
+++ b/src/sensors/SensorObject.ts
@@ -1,5 +1,7 @@
+import { AbstractMesh as BabylonAbstractMesh } from '@babylonjs/core/Meshes/abstractMesh';
+import { Scene as BabylonScene } from '@babylonjs/core/scene';
+
 import Sensor from './Sensor';
-import * as Babylon from 'babylonjs';
 import { RobotState } from '../RobotState';
 
 interface SensorObject {
@@ -16,8 +18,8 @@ interface SensorObject {
 
 namespace SensorObject {
   export interface Config<T extends Sensor> {
-    scene: Babylon.Scene;
-    mesh: Babylon.AbstractMesh;
+    scene: BabylonScene;
+    mesh: BabylonAbstractMesh;
     sensor: T
   }
 

--- a/src/sensors/TouchSensor.ts
+++ b/src/sensors/TouchSensor.ts
@@ -1,4 +1,6 @@
-import * as Babylon from 'babylonjs';
+import { AbstractMesh as BabylonAbstractMesh } from '@babylonjs/core/Meshes/abstractMesh';
+import { Observer as BabylonObserver } from '@babylonjs/core/Misc/observable';
+
 import Sensor from './Sensor';
 import SensorObject from './SensorObject';
 
@@ -6,16 +8,16 @@ export class TouchSensor implements SensorObject {
   private config_: SensorObject.Config<Sensor.Touch>;
 
   // Keeps track of the meshes in the scene that are eligible for intersection checking
-  private eligibleMeshes_: Babylon.AbstractMesh[];
-  private unprocessedMeshes_: Babylon.AbstractMesh[];
+  private eligibleMeshes_: BabylonAbstractMesh[];
+  private unprocessedMeshes_: BabylonAbstractMesh[];
 
   private isIntersecting_ = false;
-  private prevIntersectingMesh_: Babylon.AbstractMesh = null;
+  private prevIntersectingMesh_: BabylonAbstractMesh = null;
 
   private sinceLastUpdate = 0;
 
-  private meshAddedObserver_: Babylon.Observer<Babylon.AbstractMesh>;
-  private meshRemovedObserver_: Babylon.Observer<Babylon.AbstractMesh>;
+  private meshAddedObserver_: BabylonObserver<BabylonAbstractMesh>;
+  private meshRemovedObserver_: BabylonObserver<BabylonAbstractMesh>;
 
   get sensor(): Sensor.Touch {
     return this.config_.sensor;
@@ -125,13 +127,13 @@ export class TouchSensor implements SensorObject {
     // Digital sensors don't have realism
   }
 
-  private isTouchingMesh = (mesh: Babylon.AbstractMesh) => {
+  private isTouchingMesh = (mesh: BabylonAbstractMesh) => {
     return mesh.isVisible && this.config_.mesh.intersectsMesh(mesh);
   };
 
   // Determines whether the given mesh is eligible for intersection checking
   // Based on the metadata property, which will only exist for meshes created through SceneBinding
-  private static isMeshEligible = (mesh: Babylon.AbstractMesh) => {
+  private static isMeshEligible = (mesh: BabylonAbstractMesh) => {
     return typeof mesh.metadata === 'string' && mesh.metadata.length > 0;
   };
 }

--- a/src/sensors/index.ts
+++ b/src/sensors/index.ts
@@ -1,4 +1,5 @@
-import * as Babylon from 'babylonjs';
+import { Scene as BabylonScene } from '@babylonjs/core/scene';
+
 import { EtSensor } from './EtSensor';
 import { IrSensor } from './IrSensor';
 
@@ -12,7 +13,7 @@ export * from './EtSensor';
 export * from './TouchSensor';
 export { default as MAPPINGS } from './mappings';
 
-export const instantiate = (scene: Babylon.Scene, id: string, sensor: Sensor): SensorObject => {
+export const instantiate = (scene: BabylonScene, id: string, sensor: Sensor): SensorObject => {
   const mesh = scene.getMeshByID(id) || scene.getMeshByName(id);
   if (!mesh) throw new Error(`Failed to lookup mesh by ID or name (${id})`);
 

--- a/src/sensors/mappings.ts
+++ b/src/sensors/mappings.ts
@@ -1,24 +1,24 @@
+import { Vector3 as BabylonVector3 } from '@babylonjs/core/Maths/math.vector';
+
 import Sensor from './Sensor';
 import Dict from '../Dict';
-
-import * as Babylon from 'babylonjs';
 
 // Maps object names to Sensors
 export default {
   // Arm ET sensor
   'black satin finish plastic': {
     type: Sensor.Type.Et,
-    forward: new Babylon.Vector3(0.0, 0.02, 0.0),
-    origin: new Babylon.Vector3(0.02, 0.02, -0.015),
+    forward: new BabylonVector3(0.0, 0.02, 0.0),
+    origin: new BabylonVector3(0.02, 0.02, -0.015),
     output: Sensor.Output.analog(0),
     maxUpdateFrequency: 3,
   },
   // IR sensor
   'color-54': {
     type: Sensor.Type.Ir,
-    forward: new Babylon.Vector3(0.0, 0.0, -0.02),
+    forward: new BabylonVector3(0.0, 0.0, -0.02),
     // origin is offset because the mesh's center point in the model isn't actual at the center
-    origin: new Babylon.Vector3(0.012, 0, -0.025),
+    origin: new BabylonVector3(0.012, 0, -0.025),
     output: Sensor.Output.analog(1),
     maxUpdateFrequency: 1,
   },

--- a/src/state/State/Scene/Color.ts
+++ b/src/state/State/Scene/Color.ts
@@ -1,4 +1,4 @@
-import * as Babylon from 'babylonjs';
+import { Color3 as BabylonColor3 } from '@babylonjs/core/Maths/math.color';
 
 export namespace Color {
   export enum Type {
@@ -215,9 +215,9 @@ export namespace Color {
     }
   };
 
-  export const toBabylon = (color: Color): Babylon.Color3 => {
+  export const toBabylon = (color: Color): BabylonColor3 => {
     const { r, g, b } = toRgb(color);
-    return new Babylon.Color3(r / 255, g / 255, b / 255);
+    return new BabylonColor3(r / 255, g / 255, b / 255);
   };
 
   export const WHITE = rgb(255, 255, 255);

--- a/yarn.lock
+++ b/yarn.lock
@@ -241,6 +241,22 @@
     "@babel/helper-validator-identifier" "^7.14.5"
     to-fast-properties "^2.0.0"
 
+"@babylonjs/core@4.2.2", "@babylonjs/core@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@babylonjs/core/-/core-4.2.2.tgz#e37f95298700e1f2fc9a6403e297e112b2444d0b"
+  integrity sha512-gAgetSyoxFZ/xzMVVnGPKaP941NHA59Ho8GGKFW98OTEp8yZcnzJjNOD2zfF1eKmlvR/6WwSmcrKWTJtPF1pyA==
+  dependencies:
+    tslib ">=1.10.0"
+
+"@babylonjs/loaders@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@babylonjs/loaders/-/loaders-4.2.2.tgz#b57d096a050af3aa34a8dfb9952de322c216125b"
+  integrity sha512-Qk8r4xp4eOznbX3AsNYv8HgwS+tzGu6TwSpDX4il3g0B+k1N5k6KE5ghrnwDytoxUDVjGZ/VKk2cQqiHsg/NLg==
+  dependencies:
+    "@babylonjs/core" "4.2.2"
+    babylonjs-gltf2interface "4.2.2"
+    tslib ">=1.10.0"
+
 "@discordjs/builders@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-0.11.0.tgz#4102abe3e0cd093501f3f71931df43eb92f5b0cc"
@@ -1377,23 +1393,10 @@ babel-loader@^8.1.0:
     make-dir "^3.1.0"
     schema-utils "^2.6.5"
 
-babylonjs-gltf2interface@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.0.tgz#b0ef1e11e3574cf2c6f573d0c5c34857a2a7b322"
-  integrity sha512-Fn/ThxwZWP9kEAqk+9FX9CAeF4ah/I0/8wzAZR8MQuYqlYpEfM+E/IztJ+4LoOOxQYMWNs5lgj8OXSkX0tqc4g==
-
-babylonjs-loaders@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/babylonjs-loaders/-/babylonjs-loaders-4.2.0.tgz#3d536cb72bf8650fe7f1cee12380bea3227d79c0"
-  integrity sha512-GGLvo4ibbSHMY0Kj/DBu4827NBWeDT0NOBi/UuifXltzqPJtJRi3PCEcELj4Ga8cRxkfYi/7PMKcce2zVnpLZA==
-  dependencies:
-    babylonjs "4.2.0"
-    babylonjs-gltf2interface "4.2.0"
-
-babylonjs@4.2.0, babylonjs@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/babylonjs/-/babylonjs-4.2.0.tgz#8f0d957a726de4c065904b14c2f413f455145d38"
-  integrity sha512-4hniJzWRkV0tDTTYGEHPk1lnfWn0HIw7HOvNWPK0rpUIbJooyeD9E5uVyHnslDedt0mtrA7QZu4i2Cz1DEmSsA==
+babylonjs-gltf2interface@4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.2.tgz#365daf43110ec98b52379e6a9081e06b6835588b"
+  integrity sha512-LCQgW1lM+EpKK4yWMiPEgi6ONwJ7W4JrSu3t9JixNRgvnic72OnN2f0bt91rE30EJr1ZaokvkXD/aEiBp/Juyg==
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -6942,6 +6945,11 @@ ts-mixer@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-6.0.0.tgz#4e631d3a36e3fa9521b973b132e8353bc7267f9f"
   integrity sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ==
+
+tslib@>=1.10.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
Reduce bundle size by:
- Switching to Babylon core packages, allowing for much better tree shaking
- Setting `sideEffects` to `true` so that our "barrel" files (like `util/index.ts`) are properly tree shaken

This reduces the production bundle size of `login.js` from 3.6 MB to 0.25 MB and `app.js` from 8.4 MB to 6.6 MB.

Related to #67 but not closing the issue since there's more we can do