### PR TITLE
Remove main wrapper + Use WASM for C programs

### DIFF
--- a/express.js
+++ b/express.js
@@ -67,7 +67,7 @@ if (config.server.dependencies.libkipr_c && config.server.dependencies.emsdk_env
       env['EMSDK'] = config.server.dependencies.emsdk_env.EMSDK;
       env['EM_CONFIG'] = config.server.dependencies.emsdk_env.EM_CONFIG;
   
-      exec(`emcc -s WASM=0 -s INVOKE_RUN=0 -s EXIT_RUNTIME=1 -s "EXPORTED_FUNCTIONS=['_main']" -I${config.server.dependencies.libkipr_c}/include -L${config.server.dependencies.libkipr_c}/lib -lkipr -o ${path}.js ${path}`, {
+      exec(`emcc -s WASM=1 -s SINGLE_FILE=1 -s INVOKE_RUN=0 -s EXIT_RUNTIME=1 -s "EXPORTED_FUNCTIONS=['_main']" -I${config.server.dependencies.libkipr_c}/include -L${config.server.dependencies.libkipr_c}/lib -lkipr -o ${path}.js ${path}`, {
         env
       }, (err, stdout, stderr) => {
         if (err) {

--- a/src/require.ts
+++ b/src/require.ts
@@ -3,7 +3,7 @@ export interface EmscriptenModule {
   print: (s: string) => void,
   printErr: (stderror: string) => void,
   onRuntimeInitialized?: () => void,
-  _simMainWrapper?: () => void,
+  _main?: () => void,
 }
 
 export interface ModuleContext {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -57,7 +57,7 @@ const startC = (message: Protocol.Worker.StartRequest) => {
 
   mod.onRuntimeInitialized = () => {
     try {
-      mod._simMainWrapper();
+      mod._main();
     } catch (e: unknown) {
       if (ExitStatusError.isExitStatusError(e)) {
         print(`Program exited with status code ${e.status}`);
@@ -66,7 +66,7 @@ const startC = (message: Protocol.Worker.StartRequest) => {
       } else {
         printErr(`Program exited with an unknown error`);
       }
-
+    } finally {
       sendStopped();
     }
   };


### PR DESCRIPTION
- Remove `simMainWrapper()` since we no longer use Asyncify and the runtime can exit normally
- [related to #247] Use WASM for C programs. Using `SINGLE_FILE` so that the WASM gets inlined into the JS wrapper file and we can run the JS exactly as we currently do