### PR TITLE
Update ESLint ECMAScript version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     'eslint:recommended',
   ],
   env: {
-    es6: true,
+    es2020: true,
   },
   rules: {
     // Project-specific ESLint rules

--- a/express.js
+++ b/express.js
@@ -73,13 +73,7 @@ if (config.server.dependencies.libkipr_c && config.server.dependencies.emsdk_env
         });
       }
 
-      // ...process.env causes a linter error for some reason.
-      // We work around this by doing it manually.
-      
-      const env = {};
-      for (const key of Object.keys(process.env)) {
-        env[key] = process.env[key];
-      }
+      const env = { ...process.env };
       
       env['PATH'] = `${config.server.dependencies.emsdk_env.PATH}:${process.env.PATH}`;
       env['EMSDK'] = config.server.dependencies.emsdk_env.EMSDK;


### PR DESCRIPTION
Update our ESLint ECMAScript version to `es2020`, which allows the object spread operator that previously couldn't be used in `express.js` (and update `express.js` to use it)