### PR TITLE
Fix can positions

### DIFF
--- a/src/scenes/jbc10.ts
+++ b/src/scenes/jbc10.ts
@@ -12,6 +12,6 @@ export const JBC_10: Scene = {
   description: { [LocalizedString.EN_US]: 'Junior Botball Challenge 10: Solo Joust' },
   nodes: {
     ...baseScene.nodes,
-    'can1': createCanNode(1, { x: Distance.centimeters(-11), y: Distance.centimeters(0), z: Distance.centimeters(91) }),
+    'can1': createCanNode(1, { x: Distance.centimeters(11), y: Distance.centimeters(0), z: Distance.centimeters(91) }),
   }
 };

--- a/src/scenes/jbc10b.ts
+++ b/src/scenes/jbc10b.ts
@@ -12,9 +12,9 @@ export const JBC_10B: Scene = {
   description: { [LocalizedString.EN_US]: 'Junior Botball Challenge 10: Solo Joust Jr.' },
   nodes: {
     ...baseScene.nodes,
-    'can1': createCanNode(1, { x: Distance.centimeters(13), y: Distance.centimeters(0), z: Distance.centimeters(17) }), // green line
-    'can2': createCanNode(2, { x: Distance.centimeters(17), y: Distance.centimeters(0), z: Distance.centimeters(41) }), // red line
-    'can3': createCanNode(3, { x: Distance.centimeters(-11.5), y: Distance.centimeters(0), z: Distance.centimeters(51) }), // yellow line
-    'can4': createCanNode(4, { x: Distance.centimeters(-10.5), y: Distance.centimeters(0), z: Distance.centimeters(23) }), // purple line
+    'can1': createCanNode(1, { x: Distance.centimeters(-13), y: Distance.centimeters(0), z: Distance.centimeters(17) }), // green line
+    'can2': createCanNode(2, { x: Distance.centimeters(-17), y: Distance.centimeters(0), z: Distance.centimeters(41) }), // red line
+    'can3': createCanNode(3, { x: Distance.centimeters(11.5), y: Distance.centimeters(0), z: Distance.centimeters(51) }), // yellow line
+    'can4': createCanNode(4, { x: Distance.centimeters(10.5), y: Distance.centimeters(0), z: Distance.centimeters(23) }), // purple line
   }
 };

--- a/src/scenes/jbc12.ts
+++ b/src/scenes/jbc12.ts
@@ -13,7 +13,7 @@ export const JBC_12: Scene = {
   nodes: {
     ...baseScene.nodes,
     'can1': createCanNode(1, { x: Distance.centimeters(0), y: Distance.centimeters(0), z: Distance.centimeters(53.3) }),
-    'can2': createCanNode(2, { x: Distance.centimeters(-18.5), y: Distance.centimeters(0), z: Distance.centimeters(78) }),
-    'can3': createCanNode(3, { x: Distance.centimeters(12.3), y: Distance.centimeters(0), z: Distance.centimeters(93.9) }),
+    'can2': createCanNode(2, { x: Distance.centimeters(18.5), y: Distance.centimeters(0), z: Distance.centimeters(78) }),
+    'can3': createCanNode(3, { x: Distance.centimeters(-12.3), y: Distance.centimeters(0), z: Distance.centimeters(93.9) }),
   }
 };

--- a/src/scenes/jbc19.ts
+++ b/src/scenes/jbc19.ts
@@ -9,7 +9,7 @@ const baseScene = createBaseSceneSurfaceA();
 
 const REAM_ORIGIN: ReferenceFrame = {
   position: {
-    x: Distance.centimeters(10),
+    x: Distance.centimeters(-10),
     y: Distance.centimeters(-3),
     z: Distance.centimeters(91.6),
   },
@@ -25,9 +25,9 @@ export const JBC_19: Scene = {
   description: { [LocalizedString.EN_US]: `Junior Botball Challenge 19: Mountain Rescue` },
   nodes: {
     ...baseScene.nodes,
-    'can1': createCanNode(1, { x: Distance.centimeters(3), y: Distance.centimeters(6), z: Distance.centimeters(84.6) }),
-    'can2': createCanNode(2, { x: Distance.centimeters(10), y: Distance.centimeters(6), z: Distance.centimeters(91.6) }),
-    'can3': createCanNode(3, { x: Distance.centimeters(17), y: Distance.centimeters(6), z: Distance.centimeters(98.6) }),
+    'can1': createCanNode(1, { x: Distance.centimeters(-3), y: Distance.centimeters(6), z: Distance.centimeters(84.6) }),
+    'can2': createCanNode(2, { x: Distance.centimeters(-10), y: Distance.centimeters(6), z: Distance.centimeters(91.6) }),
+    'can3': createCanNode(3, { x: Distance.centimeters(-17), y: Distance.centimeters(6), z: Distance.centimeters(98.6) }),
     'ream': {
       type: 'from-template',
       templateId: 'ream',

--- a/src/scenes/jbc19.ts
+++ b/src/scenes/jbc19.ts
@@ -25,9 +25,9 @@ export const JBC_19: Scene = {
   description: { [LocalizedString.EN_US]: `Junior Botball Challenge 19: Mountain Rescue` },
   nodes: {
     ...baseScene.nodes,
-    'can1': createCanNode(1, { x: Distance.centimeters(-3), y: Distance.centimeters(6), z: Distance.centimeters(84.6) }),
+    'can1': createCanNode(1, { x: Distance.centimeters(-3), y: Distance.centimeters(6), z: Distance.centimeters(98.6) }),
     'can2': createCanNode(2, { x: Distance.centimeters(-10), y: Distance.centimeters(6), z: Distance.centimeters(91.6) }),
-    'can3': createCanNode(3, { x: Distance.centimeters(-17), y: Distance.centimeters(6), z: Distance.centimeters(98.6) }),
+    'can3': createCanNode(3, { x: Distance.centimeters(-17), y: Distance.centimeters(6), z: Distance.centimeters(84.6) }),
     'ream': {
       type: 'from-template',
       templateId: 'ream',

--- a/src/scenes/jbc20.ts
+++ b/src/scenes/jbc20.ts
@@ -11,13 +11,13 @@ const ROBOT_ORIGIN: ReferenceFrame = {
   ...baseScene.nodes['robot'].origin,
   position: {
     ...baseScene.nodes['robot'].origin.position,
-    x: Distance.centimeters(-18)
+    x: Distance.centimeters(18)
   },
 };
 
 const REAM_ORIGIN: ReferenceFrame = {
   position: {
-    x: Distance.centimeters(12),
+    x: Distance.centimeters(-12),
     y: Distance.centimeters(-3),
     z: Distance.centimeters(3),
   },

--- a/src/scenes/jbc6c.ts
+++ b/src/scenes/jbc6c.ts
@@ -13,7 +13,7 @@ export const JBC_6C: Scene = {
   nodes: {
     ...baseScene.nodes,
     'can1': createCanNode(1, { x: Distance.centimeters(0), y: Distance.centimeters(0), z: Distance.centimeters(53.3) }),
-    'can2': createCanNode(2, { x: Distance.centimeters(-18.5), y: Distance.centimeters(0), z: Distance.centimeters(78) }),
-    'can3': createCanNode(3, { x: Distance.centimeters(12.3), y: Distance.centimeters(0), z: Distance.centimeters(93.9) }),
+    'can2': createCanNode(2, { x: Distance.centimeters(18.5), y: Distance.centimeters(0), z: Distance.centimeters(78) }),
+    'can3': createCanNode(3, { x: Distance.centimeters(-12.3), y: Distance.centimeters(0), z: Distance.centimeters(93.9) }),
   }
 };

--- a/src/scenes/jbc7b.ts
+++ b/src/scenes/jbc7b.ts
@@ -28,12 +28,12 @@ export const JBC_7B: Scene = {
       startingOrigin: ROBOT_ORIGIN,
       origin: ROBOT_ORIGIN
     },
-    'can1': createCanNode(1, { x: Distance.centimeters(-24), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
-    'can2': createCanNode(2, { x: Distance.centimeters(-16), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
-    'can3': createCanNode(3, { x: Distance.centimeters(-8), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
+    'can1': createCanNode(1, { x: Distance.centimeters(24), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
+    'can2': createCanNode(2, { x: Distance.centimeters(16), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
+    'can3': createCanNode(3, { x: Distance.centimeters(8), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
     'can4': createCanNode(4, { x: Distance.centimeters(0), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
-    'can5': createCanNode(5, { x: Distance.centimeters(8), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
-    'can6': createCanNode(7, { x: Distance.centimeters(16), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
-    'can7': createCanNode(6, { x: Distance.centimeters(24), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
+    'can5': createCanNode(5, { x: Distance.centimeters(-8), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
+    'can6': createCanNode(7, { x: Distance.centimeters(-16), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
+    'can7': createCanNode(6, { x: Distance.centimeters(-24), y: Distance.centimeters(0), z: Distance.centimeters(15.5) }),
   },
 };

--- a/src/scenes/jbcBase.ts
+++ b/src/scenes/jbcBase.ts
@@ -222,7 +222,7 @@ export function createCanNode(canNumber: number, canPosition?: Vector3, editable
  */
 const canPositions: Vector3[] = [
   {
-    x: Distance.centimeters(-22.7),
+    x: Distance.centimeters(22.7),
     y: Distance.centimeters(0),
     z: Distance.centimeters(35.2),
   },
@@ -232,7 +232,7 @@ const canPositions: Vector3[] = [
     z: Distance.centimeters(28.8),
   },
   {
-    x: Distance.centimeters(16.2),
+    x: Distance.centimeters(-16.2),
     y: Distance.centimeters(0),
     z: Distance.centimeters(25.7),
   },
@@ -242,7 +242,7 @@ const canPositions: Vector3[] = [
     z: Distance.centimeters(42.7),
   },
   {
-    x: Distance.centimeters(-14.3),
+    x: Distance.centimeters(14.3),
     y: Distance.centimeters(0),
     z: Distance.centimeters(56.9),
   },
@@ -252,12 +252,12 @@ const canPositions: Vector3[] = [
     z: Distance.centimeters(57.2),
   },
   {
-    x: Distance.centimeters(13.8),
+    x: Distance.centimeters(-13.8),
     y: Distance.centimeters(0),
     z: Distance.centimeters(56.9),
   },
   {
-    x: Distance.centimeters(26),
+    x: Distance.centimeters(-26),
     y: Distance.centimeters(0),
     z: Distance.centimeters(65.5),
   },
@@ -267,7 +267,7 @@ const canPositions: Vector3[] = [
     z: Distance.centimeters(85.4),
   },
   {
-    x: Distance.centimeters(-19.3),
+    x: Distance.centimeters(19.3),
     y: Distance.centimeters(0),
     z: Distance.centimeters(96.9),
   },
@@ -277,7 +277,7 @@ const canPositions: Vector3[] = [
     z: Distance.centimeters(106.6),
   },
   {
-    x: Distance.centimeters(19.2),
+    x: Distance.centimeters(-19.2),
     y: Distance.centimeters(0),
     z: Distance.centimeters(96.9),
   },


### PR DESCRIPTION
Fixes can X positions after the `robot-schema` PR broke them by changing from a left-handed to right-handed Y-up coordinate system.