### PR TITLE
[Semio] Robot - User Interface

### DIFF
--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -569,7 +569,6 @@ class Root extends React.Component<Props, State> {
     });
   };
 
-
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     this.setState({
       modal: Modal.exception(error, info)

--- a/src/components/World/index.tsx
+++ b/src/components/World/index.tsx
@@ -320,7 +320,7 @@ class World_ extends React.PureComponent<Props & ReduxWorldProps, State> {
         onVisibilityChange: this.onItemVisibilityChange_(nodeId),
         visible: node.visible,
       }, {
-        removable: node.editable,
+        removable: node.editable && node.type !== 'robot',
         userdata: nodeId,
       }));
     }

--- a/src/robots/demobot.ts
+++ b/src/robots/demobot.ts
@@ -4,6 +4,7 @@ import Geometry from "../state/State/Robot/Geometry";
 import { Angle, Distance, Mass } from '../util';
 import { Vector3 as RawVector3 } from '../math';
 import { Rotation, Vector3 } from '../unit-math';
+import LocalizedString from '../util/LocalizedString';
 
 const { meters } = Distance;
 const { degrees } = Angle;
@@ -11,7 +12,7 @@ const { grams } = Mass;
 
 export const DEMOBOT: Robot = {
   name: {
-    'en': 'Demobot',
+    [LocalizedString.EN_US]: 'Demobot',
   },
   authorId: 'kipr',
   nodes: {

--- a/src/scenes/jbcSandboxA.ts
+++ b/src/scenes/jbcSandboxA.ts
@@ -41,6 +41,10 @@ export const JBC_Sandbox_A: Scene = {
   },
   nodes: {
     ...baseScene.nodes,
+    'robot': {
+      ...baseScene.nodes['robot'],
+      editable: true,
+    },
     'can1': createCanNode(1, undefined, true, false),
     'can2': createCanNode(2, undefined, true, false),
     'can3': createCanNode(3, undefined, true, false),

--- a/src/scenes/jbcSandboxB.ts
+++ b/src/scenes/jbcSandboxB.ts
@@ -9,4 +9,11 @@ export const JBC_Sandbox_B: Scene = {
   ...baseScene,
   name: { [LocalizedString.EN_US]: 'JBC Sandbox B' },
   description: { [LocalizedString.EN_US]: `Junior Botball Challenge Sandbox on Mat B.` },
+  nodes: {
+    ...baseScene.nodes,
+    'robot': {
+      ...baseScene.nodes['robot'],
+      editable: true,
+    },
+  }
 };

--- a/src/unit-math.ts
+++ b/src/unit-math.ts
@@ -199,7 +199,7 @@ export namespace Rotation {
     x,
     y,
     z,
-    order
+    order: order || 'yzx',
   });
 
   export const eulerDegrees = (x: number, y: number, z: number, order?: RawEuler.Order) => euler(


### PR DESCRIPTION
Allows the user to switch robots via the `NodeSettings` dialog by clicking on the Robot's settings in the `World` widget. The `robot` `Node` must be marked `editable`, which is only the case on `jbcSandbox*`.

![World Widget](https://user-images.githubusercontent.com/96179/206021129-50234307-2105-4c8f-a721-cf2877e6f538.PNG)

![Node Settings](https://user-images.githubusercontent.com/96179/206021021-a7036d81-bdc9-40ce-bd63-b858f94d28aa.png)
