### PR TITLE
[Semio] Light Sensor Support

### DIFF
--- a/src/RobotBinding.ts
+++ b/src/RobotBinding.ts
@@ -1053,6 +1053,8 @@ namespace RobotBinding {
     // Calibrated value from real sensor with overhead light on
     private static AMBIENT_LIGHT_VALUE = 4095 - 3645;
 
+    private static DEFAULT_NOISE_RADIUS = 10;
+
     private static lightValue_ = (distance: Distance) => {
       const cm = Distance.toCentimetersValue(distance);
       if (cm < 0) return 0;
@@ -1097,7 +1099,7 @@ namespace RobotBinding {
       return hit;
     }
 
-    override async getValue(): Promise<number> {
+    override getValue(): Promise<number> {
       const { scene } = this.parameters;
       this.trace_.visibility = this.visible ? 1 : 0;
 
@@ -1149,7 +1151,12 @@ namespace RobotBinding {
         valueSum += intensity * LightSensor.lightValue_(distance);
       }
 
-      return 4095 - clamp(0, valueSum, 4095);
+      if (this.noisy) {
+        const offset = Math.floor(LightSensor.DEFAULT_NOISE_RADIUS * Math.random() * 2) - LightSensor.DEFAULT_NOISE_RADIUS;
+        valueSum -= offset;
+      }
+
+      return Promise.resolve(4095 - clamp(0, valueSum, 4095));
     }
 
     override dispose(): void {

--- a/src/SceneBinding.ts
+++ b/src/SceneBinding.ts
@@ -578,7 +578,7 @@ class SceneBinding {
     );
 
     ret.intensity = node.intensity;
-
+    
     this.shadowGenerators_[id] = SceneBinding.createShadowGenerator_(ret);
 
     ret.setEnabled(node.visible);

--- a/src/ScriptManager/index.ts
+++ b/src/ScriptManager/index.ts
@@ -259,8 +259,8 @@ namespace ScriptManager {
     private spawnFunc_ = (params: Dict<unknown>, code: string) => {
       const paramNames = Object.keys(params);
       // eslint-disable-next-line @typescript-eslint/no-implied-eval
-      return new Function(paramNames.join(','), `"use strict"; ${code}`)(...paramNames.map(name => params[name]));
-    }
+      new Function(paramNames.join(','), `"use strict"; ${code}`)(...paramNames.map(name => params[name]));
+    };
 
     constructor(script: Script, manager: ScriptManager) {
       this.script_ = script;

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -212,7 +212,7 @@ export class Space {
   private async createScene(): Promise<void> {
     this.bScene_.onPointerObservable.add(this.onPointerTap_, Babylon.PointerEventTypes.POINTERTAP);
 
-    const light = new Babylon.HemisphericLight('light1', new Babylon.Vector3(0, 1, 0), this.bScene_);
+    const light = new Babylon.HemisphericLight('hemispheric_light', new Babylon.Vector3(0, 1, 0), this.bScene_);
     light.intensity = 0.5;
     light.diffuse = new Babylon.Color3(1.0, 1.0, 1.0);
 
@@ -341,8 +341,10 @@ export class Space {
     } else if (bNode instanceof Babylon.ShadowLight) {
       bPosition = bNode.position;
       bRotation = Babylon.Quaternion.Identity();
-    } else {
-      throw new Error(`Unknown node type: ${bNode.constructor.name}`);
+    } else if (bNode.getClassName() === 'PointLight') {
+      const pointLight = bNode as Babylon.PointLight;
+      bPosition = pointLight.position;
+      bRotation = Babylon.Quaternion.Identity();
     }
 
     if (bPosition) {

--- a/src/math.ts
+++ b/src/math.ts
@@ -158,6 +158,13 @@ export namespace Vector3 {
     const length = Vector3.length(lhs) * Vector3.length(rhs);
     return Math.acos(dot / length);
   };
+
+  export const clampVec = (min: Vector3, v: Vector3, max: Vector3): Vector3 => ({
+    x: clamp(min.x, v.x, max.x),
+    y: clamp(min.y, v.y, max.y),
+    z: clamp(min.z, v.z, max.z)
+  });
+    
 }
 
 export interface Euler {

--- a/src/robots/demobot.ts
+++ b/src/robots/demobot.ts
@@ -22,6 +22,14 @@ export const DEMOBOT: Robot = {
       mass: grams(1160 - 800),
       friction: 0.1,
     }),
+    lightSensor: Node.lightSensor({
+      parentId: 'chassis',
+      origin: {
+        position: Vector3.meters(0.3, 0, 0),
+        orientation: Rotation.eulerDegrees(90, 0, 0),
+      },
+      analogPort: 3,
+    }),
     wombat: Node.weight({
       parentId: 'chassis',
       mass: grams(800),

--- a/src/scenes/index.ts
+++ b/src/scenes/index.ts
@@ -34,3 +34,4 @@ export * from './jbc20';
 export * from './jbc21';
 export * from './jbc22';
 export * from './scriptPlayground';
+export * from './lightSensorTest';

--- a/src/scenes/lightSensorTest.ts
+++ b/src/scenes/lightSensorTest.ts
@@ -1,0 +1,79 @@
+import Scene from "../state/State/Scene";
+import Node from '../state/State/Scene/Node';
+import Script from '../state/State/Scene/Script';
+import { ReferenceFrame, Rotation, Vector3 } from "../unit-math";
+import { Distance } from "../util";
+import LocalizedString from '../util/LocalizedString';
+
+import { createCanNode, createBaseSceneSurfaceA } from './jbcBase';
+
+const baseScene = createBaseSceneSurfaceA();
+
+const LIGHT0_ORIGIN: ReferenceFrame = {
+  position: Vector3.meters(1, 0.5, -1),
+};
+
+const LIGHT1_ORIGIN: ReferenceFrame = {
+  position: Vector3.meters(-1, 0.5, -1),
+};
+
+const script = `
+scene.onBind = nodeId => {
+  let lastUpdate = Date.now() + Math.random() * 1000;
+  scene.addOnRenderListener(() => {
+    const now = Date.now();
+    if (now - lastUpdate < 1000) return;
+    lastUpdate = now;
+
+    const node = scene.nodes[nodeId];
+    scene.setNode(nodeId, {
+      ...node,
+      visible: !node.visible
+    });
+  });
+};
+`;
+
+export const lightSensorTest: Scene = {
+  ...baseScene,
+  name: {
+    [LocalizedString.EN_US]: 'Light Sensor Test'
+  },
+  description: {
+    [LocalizedString.EN_US]: 'Light Sensor Test'
+  },
+  nodes: {
+    ground: {
+      ...baseScene.nodes['ground']
+    },
+    robot: {
+      ...baseScene.nodes['robot'],
+      editable: true,
+    },
+    light0: {
+      type: 'point-light',
+      intensity: 0.5,
+      name: {
+        [LocalizedString.EN_US]: 'Light 0'
+      },
+      startingOrigin: LIGHT0_ORIGIN,
+      origin: LIGHT0_ORIGIN,
+      visible: true,
+      scriptIds: ['script']
+    },
+    light1: {
+      type: 'point-light',
+      intensity: 0.5,
+      name: {
+        [LocalizedString.EN_US]: 'Light 1'
+      },
+      startingOrigin: LIGHT1_ORIGIN,
+      origin: LIGHT1_ORIGIN,
+      visible: true,
+      scriptIds: ['script']
+    },
+  },
+  scripts: {
+    script: Script.ecmaScript('Script', script)
+  }
+};

--- a/src/state/State/Robot/Node.ts
+++ b/src/state/State/Robot/Node.ts
@@ -15,6 +15,7 @@ namespace Node {
     Servo = 'servo',
     EtSensor = 'et-sensor',
     TouchSensor = 'touch-sensor',
+    LightSensor = 'light-sensor',
     ReflectanceSensor = 'reflectance-sensor',
     IRobotCreate = 'irobot-create',
   }
@@ -445,6 +446,12 @@ namespace Node {
       });
     };
   }
+
+  export interface LightSensor extends Base, AnalogSensor {
+    type: Type.LightSensor;
+  }
+
+  export const lightSensor = construct<LightSensor>(Type.LightSensor);
   
   export interface ReflectanceSensor extends Base, AnalogSensor {
     type: Type.ReflectanceSensor;
@@ -521,6 +528,7 @@ type Node = (
   Node.Servo |
   Node.EtSensor |
   Node.TouchSensor |
+  Node.LightSensor |
   Node.ReflectanceSensor |
   Node.IRobotCreate
 );

--- a/src/state/reducer/scenes.ts
+++ b/src/state/reducer/scenes.ts
@@ -327,6 +327,7 @@ const DEFAULT_SCENES: Scenes = {
   jbc21: Async.loaded({ value: JBC_SCENES.JBC_21 }),
   jbc22: Async.loaded({ value: JBC_SCENES.JBC_22 }),
   scriptPlayground: Async.loaded({ value: JBC_SCENES.scriptPlayground }),
+  lightSensorTest: Async.loaded({ value: JBC_SCENES.lightSensorTest }),
 };
 
 const create = async (sceneId: string, next: Async.Creating<Scene>) => {

--- a/src/unit-math.ts
+++ b/src/unit-math.ts
@@ -94,12 +94,24 @@ export namespace Vector3 {
     Distance.toType(v.z, type).value
   );
 
+  export const toRawGranular = (v: Vector3, x: Distance.Type, y: Distance.Type, z: Distance.Type) => RawVector3.create(
+    Distance.toType(v.x, x).value,
+    Distance.toType(v.y, y).value,
+    Distance.toType(v.z, z).value
+  );
+
   export const toBabylon = (v: Vector3, type: Distance.Type) => RawVector3.toBabylon(toRaw(v || ZERO_METERS, type));
 
   export const fromRaw = (raw: RawVector3, type: Distance.Type) => ({
     x: { type, value: raw.x },
     y: { type, value: raw.y },
     z: { type, value: raw.z },
+  });
+
+  export const fromRawGranular = (raw: RawVector3, x: Distance.Type, y: Distance.Type, z: Distance.Type) => ({
+    x: { type: x, value: raw.x },
+    y: { type: y, value: raw.y },
+    z: { type: z, value: raw.z },
   });
 
   export const toTypeGranular = (v: Vector3, x: Distance.Type, y: Distance.Type, z: Distance.Type): Vector3 => {
@@ -113,6 +125,37 @@ export namespace Vector3 {
   export const distance = (lhs: Vector3, rhs: Vector3, newType: Distance.Type = 'meters'): Distance => {
     const raw = Distance.meters(RawVector3.distance(Vector3.toRaw(lhs, 'meters'), Vector3.toRaw(rhs, 'meters')));
     return Distance.toType(raw, newType);
+  };
+
+  /**
+   * Adds two vectors together
+   * 
+   * @param lhs The left hand side of the addition. The units of this vector will be used for the result.
+   * @param rhs The right hand side of the addition.
+   */
+  export const add = (lhs: Vector3, rhs: Vector3): Vector3 => {
+    const raw = RawVector3.add(Vector3.toRawGranular(lhs, lhs.x.type, lhs.y.type, lhs.z.type), Vector3.toRawGranular(rhs, lhs.x.type, lhs.y.type, lhs.z.type));
+    return Vector3.fromRawGranular(raw, lhs.x.type, lhs.y.type, lhs.z.type);
+  };
+
+  export const subtract = (lhs: Vector3, rhs: Vector3): Vector3 => {
+    const raw = RawVector3.subtract(Vector3.toRawGranular(lhs, lhs.x.type, lhs.y.type, lhs.z.type), Vector3.toRawGranular(rhs, lhs.x.type, lhs.y.type, lhs.z.type));
+    return Vector3.fromRawGranular(raw, lhs.x.type, lhs.y.type, lhs.z.type);
+  };
+
+  /**
+   * Clamp a vector between a min and max value
+   * @param min The minimum
+   * @param v The value to clamp. The units of this vector will be used for the result.
+   * @param max The maximum
+   */
+  export const clamp = (min: Vector3, v: Vector3, max: Vector3): Vector3 => {
+    const minConv = Vector3.toRawGranular(min, v.x.type, v.y.type, v.z.type);
+    const maxConv = Vector3.toRawGranular(max, v.x.type, v.y.type, v.z.type);
+    const vConv = Vector3.toRawGranular(v, v.x.type, v.y.type, v.z.type);
+
+    const raw = RawVector3.clampVec(minConv, vConv, maxConv);
+    return Vector3.fromRawGranular(raw, v.x.type, v.y.type, v.z.type);
   };
 
 }

--- a/src/unit-math.ts
+++ b/src/unit-math.ts
@@ -158,6 +158,10 @@ export namespace Vector3 {
     return Vector3.fromRawGranular(raw, v.x.type, v.y.type, v.z.type);
   };
 
+  export const length = (v: Vector3): Distance => {
+    const raw = Distance.meters(RawVector3.length(Vector3.toRaw(v, 'meters')));
+    return Distance.toType(raw, v.x.type);
+  };
 }
 
 


### PR DESCRIPTION
# Details

_Adds support for light sensors to the KIPR Simulator. Note that an arbitrary light sensor is currently placed on the Wombat. This will need to be updated before merge with the appropriate KIPR-defined location._

A `LightSensor` node may be attached to any analog port on the robot, just like other sensors. It is omnidirectional but occlusion aware via ray tracing. The light sensor is calibrated based on KIPR-provided calibration data.

A new scene called `lightSensorTest` has been added that randomly flickers two lights every second.

# Video
https://user-images.githubusercontent.com/96179/217894403-10edd34a-a9cc-4649-adda-4370364a9375.mov

