### PR TITLE
Add `addOnClickListener` to Scripts

### DIFF
--- a/src/ScriptManager/ScriptSceneBinding.ts
+++ b/src/ScriptManager/ScriptSceneBinding.ts
@@ -35,6 +35,7 @@ export interface ScriptSceneBinding {
   addOnRenderListener(cb: () => void): string;
   addOnCollisionListener(nodeId: string, cb: (otherNodeId: string, point: Vector3) => void, filterIds: Ids): string;
   addOnIntersectionListener(nodeId: string, cb: (type: 'start' | 'end', otherNodeId: string) => void, filterIds: Ids): string;
+  addOnClickListener(filterIds: Ids, cb: (nodeId: string) => void): string;
 
   removeListener(handle: string): void;
 

--- a/src/ScriptManager/index.ts
+++ b/src/ScriptManager/index.ts
@@ -146,6 +146,7 @@ namespace ScriptManager {
       Collision,
       IntersectionStart,
       IntersectionEnd,
+      Click
     }
 
     export interface Render {
@@ -178,13 +179,21 @@ namespace ScriptManager {
     }
 
     export const intersectionEnd = construct<IntersectionEnd>(Type.IntersectionEnd);
+
+    export interface Click {
+      type: Type.Click;
+      nodeId: string;
+    }
+
+    export const click = construct<Click>(Type.Click);
   }
 
   export type Event = (
     Event.Render |
     Event.Collision |
     Event.IntersectionStart |
-    Event.IntersectionEnd
+    Event.IntersectionEnd |
+    Event.Click
   );
 
   export namespace Listener {
@@ -192,6 +201,7 @@ namespace ScriptManager {
       Render,
       Collision,
       Intersection,
+      Click
     }
 
     export interface Render {
@@ -218,12 +228,21 @@ namespace ScriptManager {
     }
 
     export const intersection = construct<Intersection>(Type.Intersection);
+
+    export interface Click {
+      type: Type.Click;
+      filterIds: Set<string>;
+      cb: (nodeId: string) => void;
+    }
+
+    export const click = construct<Click>(Type.Click);
   }
 
   export type Listener = (
     Listener.Render |
     Listener.Collision |
-    Listener.Intersection
+    Listener.Intersection |
+    Listener.Click
   );
 
   export type CachedListener = Omit<Listener.Collision | Listener.Intersection, 'cb' | 'nodeId'>;
@@ -299,6 +318,10 @@ namespace ScriptManager {
           this.triggerIntersection_(event);
           break;
         }
+        case Event.Type.Click: {
+          this.triggerClick_(event);
+          break;
+        }
       }
     }
 
@@ -324,6 +347,14 @@ namespace ScriptManager {
         if (listener.nodeId !== event.nodeId) continue;
         if (listener.filterIds && !listener.filterIds.has(event.otherNodeId)) continue;
         listener.cb(event.type === Event.Type.IntersectionStart ? 'start' : 'end', event.otherNodeId);
+      }
+    }
+
+    private triggerClick_(event: Event.Click) {
+      for (const listener of Dict.values(this.listeners_)) {
+        if (listener.type !== Listener.Type.Click) continue;
+        if (listener.filterIds && !listener.filterIds.has(event.nodeId)) continue;
+        listener.cb(event.nodeId);
       }
     }
 
@@ -469,6 +500,12 @@ namespace ScriptManager {
       const listener = Listener.intersection({ nodeId, cb, filterIds: Ids.toSet(filterIds) });
       this.listeners_[handle] = listener;
       this.manager_.addIntersectionRefCounts_(listener);
+      return handle;
+    }
+
+    addOnClickListener(filterIds: Ids, cb: (nodeId: string) => void): string {
+      const handle = uuid();
+      this.listeners_[handle] = Listener.click({ filterIds: Ids.toSet(filterIds), cb });
       return handle;
     }
 

--- a/src/Sim.tsx
+++ b/src/Sim.tsx
@@ -199,6 +199,11 @@ export class Space {
 
     const mesh = eventData.pickInfo.pickedMesh;
     const id = (mesh.metadata as SceneMeshMetadata).id;
+
+    this.sceneBinding_.scriptManager.trigger(ScriptManager.Event.click({
+      nodeId: id,
+    }));
+
     const prevId = this.scene_.selectedNodeId;
     if (id !== prevId && this.scene_.nodes[id]?.editable) {
       this.onSelectNodeId?.(id);
@@ -218,8 +223,6 @@ export class Space {
     // Full gravity will be -9.8 * 10
     const gravityVector = new Babylon.Vector3(0, -9.8 * 50, 0);
     
-    
-
     const state = store.getState();
     
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any

--- a/src/scenes/scriptPlayground.ts
+++ b/src/scenes/scriptPlayground.ts
@@ -11,6 +11,26 @@ import tr from '@i18n';
 
 const baseScene = createBaseSceneSurfaceA();
 
+const clicked = `
+// When the robot is clicked, the cans 1-4 become visible.
+
+const setNodeVisible = (nodeId, visible) => scene.setNode(nodeId, {
+  ...scene.nodes[nodeId],
+  visible
+});
+
+let clicked = false;
+
+scene.addOnClickListener(['robot', 'volume'], id => {
+  clicked = !clicked;
+  console.log('Clicked!', id, clicked);
+  setNodeVisible('can1', clicked);
+  setNodeVisible('can2', clicked);
+  setNodeVisible('can3', clicked);
+  setNodeVisible('can4', clicked);
+});
+`;
+
 const intersection = `
 // While the robot is intersecting "volume", cans 10-12 are visible.
 
@@ -50,6 +70,7 @@ export const scriptPlayground: Scene = {
   scripts: {
     'intersection': Script.ecmaScript('Intersection', intersection),
     'collision': Script.ecmaScript('Collision', collision),
+    'clicked': Script.ecmaScript('Clicked', clicked),
   },
   geometry: {
     ...baseScene.geometry,


### PR DESCRIPTION
This PR adds click events to scripts.

```ts
scene.addOnClickListener('nodeId', id => console.log(id, 'clicked!'));
scene.addOnClickListener(['node1', 'node2'], id => console.log(id, 'clicked!'));
```