### PR TITLE
Fix: distance sensor reads on non selected meshes

### DIFF
--- a/src/simulator/babylonBindings/sensors/EtSensor.ts
+++ b/src/simulator/babylonBindings/sensors/EtSensor.ts
@@ -60,7 +60,7 @@ class EtSensor extends SensorObject<Node.EtSensor, number> {
         mesh !== this.trace_ &&
         !links.has(mesh as Mesh) &&
         !colliders.has(mesh as Mesh) &&
-        (!!mesh.physicsImpostor || metadata.selected)
+        (!!mesh.physicsImpostor || !metadata.selected)
       );
     });
 


### PR DESCRIPTION
Distance sensor was reading on selected meshes rather than on non selected meshes, is now fixed.