### PR TITLE
Update README with new env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,16 +145,22 @@ In another terminal, run the server:
 node express.js
 ```
 
+See [Configuration](#configuration) for environment variables. The server will not run unless the required environment variables are set.
+
 ## Configuration
 
-The server can be configured using environment variables. Variables without default values must be provided.
+The server can be configured using environment variables. Some variables are required.
 
-| Variable | Description | Default value |
-| -------- | ----------- | ------------- |
-| `SERVER_PORT` | The port on which to listen for requests | `3000` |
-| `CACHING_STATIC_MAX_AGE` | The max duration (in ms) to allow static assets to be cached | `3600000` (1 hr) |
-| `FEEDBACK_WEBHOOK_URL` | The url for the discord webhook to send feedback to | | 
-| `API_URL` | The url for the KIPR database server | `https://db-prerelease.botballacademy.org` |
+| Variable | Description | Default value | Required |
+| -------- | ----------- | ------------- | -------- |
+| `SERVER_PORT` | The port on which to listen for requests | `3000` | no |
+| `CACHING_STATIC_MAX_AGE` | The max duration (in ms) to allow static assets to be cached | `3600000` (1 hr) | no |
+| `FEEDBACK_WEBHOOK_URL` | The url for the discord webhook to send feedback to | | no |
+| `API_URL` | The url for the KIPR database server | `https://db-prerelease.botballacademy.org` | no |
+| `FIREBASE_SERVICE_ACCOUNT_KEY_FILE` | Firebase service account key JSON (as a file path). Only used if `FIREBASE_SERVICE_ACCOUNT_KEY_STRING` is not present | | yes* |
+| `FIREBASE_SERVICE_ACCOUNT_KEY_STRING` | Firebase service account key JSON (as a string) | | yes* |
+| `MAILGUN_API_KEY` | API key for Mailgun service | | no |
+| `MAILGUN_DOMAIN` | Domain used for Mailgun emails | | no |
 
 ## Using a local `database` service
 

--- a/config.js
+++ b/config.js
@@ -41,8 +41,9 @@ module.exports = {
         serviceAccountKey,
       },
       mailgun: {
-        apiKey: getEnvVarOrDefault('MAILGUN_API_KEY', ''),
-        domain: getEnvVarOrDefault('MAILGUN_DOMAIN', ''),
+        // Provide defaults so mailgun client can be created even if not configured during local development
+        apiKey: getEnvVarOrDefault('MAILGUN_API_KEY', '<invalid>'),
+        domain: getEnvVarOrDefault('MAILGUN_DOMAIN', '<invalid>'),
       },
     };
   },


### PR DESCRIPTION
Update the README to document the new environment variables that were introduced in the EULA PR.

Also makes mailgun vars optional for local development. If not provided, the server will still start, but email functionality won't work.