### PR TITLE
Remove pdf.js CDN references

### DIFF
--- a/src/components/Login/UserConsentCard.tsx
+++ b/src/components/Login/UserConsentCard.tsx
@@ -7,11 +7,10 @@ import { StyleProps } from "util/style";
 import { faSignInAlt } from "@fortawesome/free-solid-svg-icons";
 import { TabBar } from "../Layout/TabBar";
 import PdfPage from "../PdfPage";
-import { GlobalWorkerOptions, PDFPageProxy, getDocument } from 'pdfjs-dist';
+import { PDFPageProxy, getDocument } from 'pdfjs-dist';
 
-// TODO: make this point to a local file that gets deployed
-// TODO: centralize somewhere in the app
-GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.4.168/pdf.worker.min.mjs';
+// Zero-configuration setup for PDF.js worker with webpack
+import 'pdfjs-dist/webpack.mjs';
 
 export interface UserConsentCardPublicProps extends ThemeProps, StyleProps {
   disable: boolean;

--- a/src/components/Login/login.html.ejs
+++ b/src/components/Login/login.html.ejs
@@ -10,7 +10,6 @@
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.4.168/pdf_viewer.css" rel="stylesheet" integrity="sha512-twLlviy1Zgoxp1EQFJJpl7aqDbGLmgLAkf9+PoGKEJbTQO7rSkVirXW0Ie/IesNjGigIMORvqAAnueKj3eTEgw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <style>
     * {
       box-sizing: border-box;

--- a/src/components/ParentalConsent/parental-consent.html.ejs
+++ b/src/components/ParentalConsent/parental-consent.html.ejs
@@ -10,7 +10,6 @@
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.4.168/pdf_viewer.css" rel="stylesheet" integrity="sha512-twLlviy1Zgoxp1EQFJJpl7aqDbGLmgLAkf9+PoGKEJbTQO7rSkVirXW0Ie/IesNjGigIMORvqAAnueKj3eTEgw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <style>
     * {
       box-sizing: border-box;

--- a/src/components/PdfPage.tsx
+++ b/src/components/PdfPage.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { styled } from 'styletron-react';
-import { GlobalWorkerOptions, PDFPageProxy, PixelsPerInch } from 'pdfjs-dist';
+import { PDFPageProxy, PixelsPerInch } from 'pdfjs-dist';
 import { EventBus, LinkTarget, PDFPageView, SimpleLinkService } from 'pdfjs-dist/web/pdf_viewer.mjs';
+import 'pdfjs-dist/web/pdf_viewer.css';
 
-GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.4.168/pdf.worker.min.mjs';
+// Zero-configuration setup for PDF.js worker with webpack
+import 'pdfjs-dist/webpack.mjs';
 
 interface PdfPageProps {
   pdfPage: PDFPageProxy;

--- a/src/pages/ParentalConsentPage.tsx
+++ b/src/pages/ParentalConsentPage.tsx
@@ -10,12 +10,11 @@ import KIPR_LOGO_WHITE from '../../static/assets/KIPR-Logo-White-Text-Clear-Larg
 import { faPaperPlane, faArrowRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesome } from "../components/FontAwesome";
 import Button from '../components/interface/Button';
-import { GlobalWorkerOptions, PDFDocumentProxy, PDFPageProxy, getDocument } from 'pdfjs-dist';
-import PdfPage from '../components/PdfPage';
+import { PDFDocumentProxy, PDFPageProxy, getDocument } from 'pdfjs-dist';
+import PdfPage from '../components/PdfPage'
 
-// TODO: make this point to a local file that gets deployed
-// TODO: centralize somewhere in the app
-GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.4.168/pdf.worker.min.mjs';
+// Zero-configuration setup for PDF.js worker with webpack
+import 'pdfjs-dist/webpack.mjs';
 
 interface ParentalConsentPageProps extends ThemeProps, StyleProps {
   userId: string;


### PR DESCRIPTION
Currently, for some pdf.js resources (like worker JS file and CSS file), we point to CDN URLs. This could cause problems in the future if we upgrade our pdf.js version without changing all the CDN URLs.

This PR removes the CDN references entirely and instead bundles the necessary files from pdfjs-dist directly.

There should be no change in behavior for users.