### PR TITLE
Fix FS errors when running Python programs

### DIFF
--- a/src/programming/python/index.ts
+++ b/src/programming/python/index.ts
@@ -47,14 +47,15 @@ if (SIMULATOR_HAS_CPYTHON) {
         }));
         let create: unknown;
         if (params.createSerial) {
-          create = module.FS.makedev(64, 0);
+          // NOTE: This was initially using a major ID of 64, but that overrode the registers device.
+          // Needs to be revisited when completing create support.
+          create = module.FS.makedev(65, 0);
           module.FS.registerDevice(create, createDevice({
             serial: params.createSerial
           }));
         }
         module.FS.mkdev('/registers', registers);
         module.FS.mkdir('/kipr');
-        module.FS.mkdir('/dev');
         if (create) module.FS.mkdev('/dev/ttyUSB0', create);
         module.FS.writeFile('/kipr/_kipr.so', new Uint8Array(libkiprBuffer));
 


### PR DESCRIPTION
Fixes #508:
- Remove creation of `/dev` directory. This is causing the "FS error" when running a Python program. It isn't needed since `/dev` already exists
- Change the device ID of the create device. I'm not sure what it's supposed to be, but currently it uses the same ID as the registers, which overrides the registers device. This will need to be revisited when Create support is fixed (#518)