### PR TITLE
Disable challenge button if unavailable

### DIFF
--- a/src/components/Challenge/LoadingOverlay.tsx
+++ b/src/components/Challenge/LoadingOverlay.tsx
@@ -60,6 +60,18 @@ const LoadingButton = withStyleDeep(Button, {
 });
 
 const LoadingOverlay = ({ challenge, loading, onStartClick, locale }: { challenge: AsyncChallenge; onStartClick: () => void; loading: boolean; locale: LocalizedString.Language; }) => {
+  const didChallengeFail: boolean = Async.isFailed(challenge);
+
+  if (didChallengeFail) {
+    return (
+      <Container>
+        <TitleContainer>
+          {LocalizedString.lookup(tr('Failed to load challenge'), locale)}
+        </TitleContainer>
+      </Container>
+    );
+  }
+
   const latestChallenge = Async.latestValue(challenge);
   if (!latestChallenge) return null;
 

--- a/src/components/Challenge/SimMenu.tsx
+++ b/src/components/Challenge/SimMenu.tsx
@@ -347,10 +347,12 @@ class SimMenu extends React.PureComponent<Props, State> {
           <Item
             theme={theme}
             onClick={onStartChallengeClick}
+            disabled={onStartChallengeClick === undefined}
+            title={onStartChallengeClick === undefined ? LocalizedString.lookup(tr('The current scene does not have a challenge available'), locale) : undefined}
             style={{ position: 'relative' }}
           >
             <ItemIcon icon={faFlagCheckered} /> {LocalizedString.lookup(tr('Start Challenge'), locale)}
-             
+            
           </Item>
 
           <Item 

--- a/src/pages/Root.tsx
+++ b/src/pages/Root.tsx
@@ -78,6 +78,7 @@ interface RootPrivateProps {
   scene: AsyncScene;
   challenge?: AsyncChallenge;
   challengeCompletion?: AsyncChallengeCompletion;
+  sceneHasChallenge: boolean;
   locale: LocalizedString.Language;
 
   onNodeAdd: (id: string, node: Node) => void;
@@ -596,7 +597,8 @@ class Root extends React.Component<Props, State> {
       match: { params: { sceneId, challengeId } },
       scene,
       challenge,
-      challengeCompletion
+      challengeCompletion,
+      sceneHasChallenge,
     } = props;
 
     if (!scene || scene.type === Async.Type.Unloaded) {
@@ -701,7 +703,7 @@ class Root extends React.Component<Props, State> {
             onSettingsClick={this.onModalClick_(Modal.SETTINGS)}
             onAboutClick={this.onModalClick_(Modal.ABOUT)}
             onResetWorldClick={this.onResetWorldClick_}
-            onStartChallengeClick={this.onStartChallengeClick_}
+            onStartChallengeClick={sceneHasChallenge ? this.onStartChallengeClick_ : undefined}
             onRunClick={code[activeLanguage].length > 0 ? this.onRunClick_ : undefined}
             onStopClick={this.onStopClick_}
             onDocumentationClick={onDocumentationClick}
@@ -822,12 +824,15 @@ class Root extends React.Component<Props, State> {
 export default connect((state: ReduxState, { match: { params: { sceneId, challengeId } } }: RootPublicProps) => {
   const builder = new Builder(state);
 
+  let sceneHasChallenge = true;
+
   if (challengeId) {
     const challenge = builder.challenge(challengeId);
     challenge.scene();
     challenge.completion();
   } else {
     builder.scene(sceneId);
+    sceneHasChallenge = sceneId in builder.state.challenges;
   }
 
   builder.dispatchLoads();
@@ -836,6 +841,7 @@ export default connect((state: ReduxState, { match: { params: { sceneId, challen
     scene: Dict.unique(builder.scenes),
     challenge: Dict.unique(builder.challenges),
     challengeCompletion: Dict.unique(builder.challengeCompletions),
+    sceneHasChallenge,
     locale: state.i18n.locale,
   };
 }, (dispatch, { match: { params: { sceneId } } }: RootPublicProps) => ({


### PR DESCRIPTION
Fixes #510:
- Disable challenge button if the current scene doesn't have a challenge. Also show a tooltip explaining why it's disabled

  When challenge doesn't exist:
  ![image](https://github.com/user-attachments/assets/a247b3b4-adb7-41b5-a8b3-bf0b0e265327)

  When challenge exists:
  ![image](https://github.com/user-attachments/assets/d86fc87e-0842-4a33-a1b4-f5fa154ae45d)

- Show an error on the challenge loading screen if the challenge doesn't exist. This shouldn't happen normally, but if the user navigates to a `/challenge/<invalid>` URL, they'll see an error instead of a blank screen

  ![image](https://github.com/user-attachments/assets/880b2458-ca0d-4c70-9561-90f926118b13)
