### PR TITLE
Add blank lines in default programs

### DIFF
--- a/src/programming/compiler/ProgrammingLanguage.ts
+++ b/src/programming/compiler/ProgrammingLanguage.ts
@@ -10,8 +10,8 @@ namespace ProgrammingLanguage {
 
 
   export const DEFAULT_CODE: { [key in ProgrammingLanguage]: string } = {
-    c: '#include <stdio.h>\n#include <kipr/wombat.h>\n\nint main()\n{\n  printf("Hello, World!\\n");\n  return 0;\n}\n',
-    cpp: '#include <iostream>\n#include <kipr/wombat.hpp>\n\nint main()\n{\n  std::cout << "Hello, World!" << std::endl;\n  return 0;\n}\n',
+    c: '#include <stdio.h>\n#include <kipr/wombat.h>\n\nint main()\n{\n  printf("Hello, World!\\n");\n\n  return 0;\n}\n',
+    cpp: '#include <iostream>\n#include <kipr/wombat.hpp>\n\nint main()\n{\n  std::cout << "Hello, World!" << std::endl;\n\n  return 0;\n}\n',
     python: 'from kipr import *\n\nprint(\'Hello, World!\')',
     scratch: ''
   };


### PR DESCRIPTION
Adds an extra blank line in the default C and C++ programs before the `return` statements, to help users insert code more easily.

The previous default for C was:

```c
#include <stdio.h>
#include <kipr/wombat.h>

int main()
{
  printf("Hello, World!\n");
  return 0;
}
```

and now it's:

```c
#include <stdio.h>
#include <kipr/wombat.h>

int main()
{
  printf("Hello, World!\n");

  return 0;
}
```