### PR TITLE
Clarify git-lfs step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cd dependencies/kipr-scratch/libwallaby && git submodule update --init
 
 ### Pull large files
 > [!TIP]
-> This step is optional for building the project but required for it to functional properly at runtime.
+> This step is optional for building the project but required for it to function properly at runtime.
 
 ```bash
 git lfs pull

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ git submodule update --init
 cd dependencies/kipr-scratch/libwallaby && git submodule update --init
 ```
 
-### Optional: Pull large files
+### Pull large files
+> [!TIP]
+> This step is optional for building the project but required for it to functional properly at runtime.
 
 ```bash
 git lfs pull


### PR DESCRIPTION
This PR clarifies in the `README` that the `git lfs pull` step is required for the project to work properly at runtime. Currently it seems like an optional step.