### PR TITLE
Make sensor detection box not pickable

### DIFF
--- a/src/simulator/babylonBindings/createRobotObjects/createLink.ts
+++ b/src/simulator/babylonBindings/createRobotObjects/createLink.ts
@@ -163,5 +163,6 @@ export const createLink = async (id: string, link: Node.Link, bScene_: babylonSc
       throw new Error(`Unsupported collision body type: ${link.collisionBody.type}`);
     }
   }
+  myMesh.isPickable = false;
   return myMesh;
 };

--- a/src/simulator/babylonBindings/createRobotObjects/createWeight.ts
+++ b/src/simulator/babylonBindings/createRobotObjects/createWeight.ts
@@ -14,6 +14,7 @@ import Dict from '../../../util/objectOps/Dict';
 export const createWeight = (id: string, weight: Node.Weight, bScene_: babylonScene, robot_: Robot, links_: Dict<Mesh>) => {
   const ret = CreateSphere(id, { diameter: 1 }, bScene_);
   ret.visibility = 0;
+  ret.isPickable = false;
 
   const parent = robot_.nodes[weight.parentId];
   if (!parent) throw new Error(`Missing parent: "${weight.parentId}" for weight "${id}"`);

--- a/src/simulator/babylonBindings/sensors/EtSensor.ts
+++ b/src/simulator/babylonBindings/sensors/EtSensor.ts
@@ -35,6 +35,7 @@ class EtSensor extends SensorObject<Node.EtSensor, number> {
       ],
     }, scene);
     this.trace_.visibility = 0;
+    this.trace_.isPickable = false;
 
     ReferenceFramewUnits.syncBabylon(origin, this.trace_, 'meters');
     this.trace_.parent = parent;

--- a/src/simulator/babylonBindings/sensors/LightSensor.ts
+++ b/src/simulator/babylonBindings/sensors/LightSensor.ts
@@ -55,6 +55,7 @@ class LightSensor extends SensorObject<Node.LightSensor, number> {
     this.trace_.parent = parameters.parent;
 
     this.trace_.visibility = 0;
+    this.trace_.isPickable = false;
   }
 
   intersects(ray: Ray) {

--- a/src/simulator/babylonBindings/sensors/ReflectanceSensor.ts
+++ b/src/simulator/babylonBindings/sensors/ReflectanceSensor.ts
@@ -36,6 +36,7 @@ class ReflectanceSensor extends SensorObject<Node.ReflectanceSensor, number> {
       ],
     }, scene);
     this.trace_.visibility = 1;
+    this.trace_.isPickable = false;
 
     ReferenceFramewUnits.syncBabylon(origin, this.trace_, 'meters');
     this.trace_.parent = parent;

--- a/src/simulator/babylonBindings/sensors/TouchSensor.ts
+++ b/src/simulator/babylonBindings/sensors/TouchSensor.ts
@@ -43,6 +43,7 @@ class TouchSensor extends SensorObject<Node.TouchSensor, boolean> {
     this.intersector_.material = new StandardMaterial('touch-sensor-material', scene);
     this.intersector_.material.wireframe = true;
     this.intersector_.visibility = 0;
+    this.intersector_.isPickable = false;
 
     // ReferenceFramewUnits.syncBabylon(origin, this.intersector_, 'meters');
   }


### PR DESCRIPTION
Fixes #516 by making the sensor detection boxes and collision boxes not pickable.
There are no more invisible barriers that prevent you from clicking through them, though you still can't click through the visible meshes.