### PR TITLE
Can fixes

### DIFF
--- a/src/simulator/babylonBindings/SceneBinding.ts
+++ b/src/simulator/babylonBindings/SceneBinding.ts
@@ -731,21 +731,16 @@ class SceneBinding {
 
     /*
      * PhysicsShape requires some information to create the shape, depending on exactly what shape you want.
-     * Cylinders and boxes, for example require different parameters, so we handle those seperately.
+     * Cylinders and boxes require different parameters, so we handle those seperately.
      * For more info, see: https://doc.babylonjs.com/features/featuresDeepDive/physics/shapes
      */
     const scale = RawVector3.toBabylon(objectNode.origin.scale ?? { x: 1, y: 1, z: 1 });
     let parameters: PhysicsShapeParameters = { mesh: physics_mesh as Mesh };
+    let physicsType = objectNode.physics.type;
 
-    // WARNING: These numbers are correct for the cans, but must be changed if we ever include any other cylinders
-    // NOTE: points A and B are relative to the parent attached visual mesh
+    // The built-in PhysicsShapeCylinder cannot be distorted on x and z independently for scaling, so instead use the visual mesh
     if (objectNode.physics.type === 'cylinder') {
-      parameters = {
-        ...parameters,
-        pointA: new Vector3(0, -(11.15 * 0.5), 0),
-        pointB: new Vector3(0, (11.15 * 0.5), 0),
-        radius: 3,
-      };
+      physicsType = 'mesh';
     } else if (objectNode.physics.type === 'box') {
       // The final multiplication by [2, 2, 2] is required to make collision boxes scale correctly
       const extend = physics_mesh.getBoundingInfo().boundingBox.extendSize.multiply(scale).multiply(new Vector3(2, 2, 2));
@@ -760,7 +755,7 @@ class SceneBinding {
      * It knows how to create some shapes automatically, based on the mesh that we gave it above.
      * For example, it can automatically create a box or a cylinder around an object, or it can use the mesh itself.
      */
-    const options: PhysicShapeOptions = { type: PHYSICS_SHAPE_TYPE_MAPPINGS[objectNode.physics.type], parameters };
+    const options: PhysicShapeOptions = { type: PHYSICS_SHAPE_TYPE_MAPPINGS[physicsType], parameters };
     const shape = new PhysicsShape(options, this.bScene);
     shape.material = {
       friction: objectNode.physics.friction ?? 0.2,

--- a/src/simulator/definitions/nodes/index.ts
+++ b/src/simulator/definitions/nodes/index.ts
@@ -10,6 +10,8 @@ import { BB2025Templates, BB2025Geometries } from "./2025gameTableTemplates";
 
 // TODO: Consider deep-freezing all of these objects
 
+const DEAULT_FACEUVS = [RawVector2.ZERO, RawVector2.ZERO, RawVector2.create(0, 1), RawVector2.create(1, 0), RawVector2.ZERO, RawVector2.ZERO];
+
 const canTemplate: Node.TemplatedNode<Node.Obj> = {
   type: 'object',
   geometryId: 'can',
@@ -27,7 +29,7 @@ const canTemplate: Node.TemplatedNode<Node.Obj> = {
       uri: '/static/textures/Can_Texture.png'
     },
   },
-  faceUvs: [RawVector2.ZERO, RawVector2.ZERO, RawVector2.create(1, 0), RawVector2.create(0, 1), RawVector2.ZERO, RawVector2.ZERO],
+  faceUvs: DEAULT_FACEUVS,
 };
 
 const circleTemplate: Node.TemplatedNode<Node.Obj> = {
@@ -59,7 +61,7 @@ const lifescienceTemplate: Node.TemplatedNode<Node.Obj> = {
       uri: '/static/textures/sciencepack/life_science_pack.png'
     },
   },
-  faceUvs: [RawVector2.ZERO, RawVector2.ZERO, RawVector2.create(1, 0), RawVector2.create(0, 1), RawVector2.ZERO, RawVector2.ZERO],
+  faceUvs: DEAULT_FACEUVS,
 };
 
 const radscienceTemplate: Node.TemplatedNode<Node.Obj> = {
@@ -78,7 +80,7 @@ const radscienceTemplate: Node.TemplatedNode<Node.Obj> = {
       uri: '/static/textures/sciencepack/rad_science_pack.png'
     },
   },
-  faceUvs: [RawVector2.ZERO, RawVector2.ZERO, RawVector2.create(1, 0), RawVector2.create(0, 1), RawVector2.ZERO, RawVector2.ZERO],
+  faceUvs: DEAULT_FACEUVS,
 };
 
 const noradscienceTemplate: Node.TemplatedNode<Node.Obj> = {
@@ -97,7 +99,7 @@ const noradscienceTemplate: Node.TemplatedNode<Node.Obj> = {
       uri: '/static/textures/sciencepack/no_rad_science_pack.png'
     },
   },
-  faceUvs: [RawVector2.ZERO, RawVector2.ZERO, RawVector2.create(1, 0), RawVector2.create(0, 1), RawVector2.ZERO, RawVector2.ZERO],
+  faceUvs: DEAULT_FACEUVS,
 };
 
 const reamTemplate: Node.TemplatedNode<Node.Obj> = {

--- a/src/simulator/definitions/scenes/jbcBase.ts
+++ b/src/simulator/definitions/scenes/jbcBase.ts
@@ -227,7 +227,6 @@ export function createBaseSceneSurfaceB(): Scene {
 export function createCanNode(canNumber: number, canPosition?: Vector3wUnits, editable?: boolean, visible?: boolean): Node {
   const origin: ReferenceFramewUnits = {
     position: canPosition ?? canPositions[canNumber - 1],
-    orientation: RotationwUnits.eulerDegrees(180, 0, 0),
   };
 
   return {


### PR DESCRIPTION
Fix two issues with JBC cans:
1. The can's collision mesh didn't scale with the visual mesh.
2. The cans started upside-down by default, which meant only cans added through `createCanNode` were correctly oriented.