### PR TITLE
Fix context menu opening when panning in some web browsers

### DIFF
--- a/src/simulator/babylonBindings/SceneBinding.ts
+++ b/src/simulator/babylonBindings/SceneBinding.ts
@@ -78,6 +78,11 @@ class SceneBinding {
 
   set canvas(canvas: HTMLCanvasElement) {
     this.canvas_ = canvas;
+
+    //Stop the context menu from opening in some web browsers
+    canvas.oncontextmenu = (e) => {
+      e.preventDefault();
+    }
     const engine = this.bScene_.getEngine();
     if (this.engineView_) engine.unRegisterView(this.engineView_.target);
     this.engineView_ = engine.registerView(this.canvas_);

--- a/src/simulator/babylonBindings/SceneBinding.ts
+++ b/src/simulator/babylonBindings/SceneBinding.ts
@@ -79,7 +79,7 @@ class SceneBinding {
   set canvas(canvas: HTMLCanvasElement) {
     this.canvas_ = canvas;
 
-    //Stop the context menu from opening in some web browsers
+    // Stop the context menu from opening in some web browsers
     canvas.oncontextmenu = (e) => {
       e.preventDefault();
     }

--- a/src/simulator/babylonBindings/SceneBinding.ts
+++ b/src/simulator/babylonBindings/SceneBinding.ts
@@ -82,7 +82,7 @@ class SceneBinding {
     // Stop the context menu from opening in some web browsers
     canvas.oncontextmenu = (e) => {
       e.preventDefault();
-    }
+    };
     const engine = this.bScene_.getEngine();
     if (this.engineView_) engine.unRegisterView(this.engineView_.target);
     this.engineView_ = engine.registerView(this.canvas_);


### PR DESCRIPTION
Stops the "save image as" dialog when trying to pan with right click