### PR TITLE
Adjust cans upright logic in challenge 6 and 7.

### DIFF
--- a/src/simulator/definitions/scenes/jbc6-Figure-Eight.ts
+++ b/src/simulator/definitions/scenes/jbc6-Figure-Eight.ts
@@ -101,9 +101,8 @@ const EULER_IDENTITY = RotationwUnits.EulerwUnits.identity();
 const yAngle = (nodeId) => 180 / Math.PI * -1 * Math.asin(Vector3wUnits.dot(Vector3wUnits.applyQuaternion(Vector3wUnits.Y, RotationwUnits.toRawQuaternion(scene.nodes[nodeId].origin.orientation || EULER_IDENTITY)), Vector3wUnits.Y));
 
 scene.addOnRenderListener(() => {
- 
-  const upright4 = yAngle('can4') > 5;
-  const upright9 = yAngle('can9') > 5;
+  const upright4 = Math.abs(yAngle('can4') + 90) < 5;
+  const upright9 = Math.abs(yAngle('can9') + 90) < 5;
   
   scene.setChallengeEventValue('can4Upright', upright4);
   scene.setChallengeEventValue('can9Upright', upright9);

--- a/src/simulator/definitions/scenes/jbc7-Load-Em-Up.ts
+++ b/src/simulator/definitions/scenes/jbc7-Load-Em-Up.ts
@@ -53,17 +53,17 @@ const yAngle = (nodeId) => 180 / Math.PI * -1 * Math.asin(Vector3wUnits.dot(Vect
 
 
 scene.addOnRenderListener(() => {
-  const upright2 = yAngle('can2') > 5;
+  const upright2 = Math.abs(yAngle('can2') + 90) < 5;
   scene.setChallengeEventValue('can2Upright', upright2);
 
 });
 scene.addOnRenderListener(() => {
-  const upright9 = yAngle('can9') > 5;
+  const upright9 = Math.abs(yAngle('can9') + 90) < 5;
   scene.setChallengeEventValue('can9Upright', upright9);
 
 });
 scene.addOnRenderListener(() => {
-  const upright10 = yAngle('can10') > 5;
+  const upright10 = Math.abs(yAngle('can10') + 90) < 5;
   scene.setChallengeEventValue('can10Upright', upright10);
 });
 `;


### PR DESCRIPTION
The cans weren't ever registering as being upright. This PR should fix challenge 6 and 7, and be able to be used to fix the remaining challenges with an upright can requirement. The yAngle was outputting -90 when upright, so the adjustment should check for the can being upright within a tolerance of 5 degrees.