### PR TITLE
Bug/skewering

### DIFF
--- a/src/simulator/babylonBindings/SceneBinding.ts
+++ b/src/simulator/babylonBindings/SceneBinding.ts
@@ -4,7 +4,7 @@ import {
   TransformNode, AbstractMesh, Mesh, PhysicsViewer, ShadowGenerator, Vector3, StandardMaterial, GizmoManager,
   ArcRotateCamera, PointLight, SpotLight, DirectionalLight, PBRMaterial, EngineView,
   Scene as babylonScene, Node as babylonNode, Camera as babylCamera, Material as babylMaterial,
-  Observer, BoundingBox, PhysicsShapeParameters, PhysicShapeOptions, PhysicsShape, PhysicsBody, PhysicsMotionType,
+  Observer, BoundingBox, PhysicsShapeParameters, PhysicShapeOptions, PhysicsShape, PhysicsBody, PhysicsMotionType, Quaternion,
 } from '@babylonjs/core';
 
 // eslint-disable-next-line @typescript-eslint/no-duplicate-imports -- Required import for side effects
@@ -679,6 +679,59 @@ class SceneBinding {
     callback: (collisionEvent: IPhysicsCollisionEvent) => void;
   }[]> = {};
 
+  /**
+  * Determine the `PhysicsShapeParameters` for a `Node`. This function is adapted from `_addSizeOptions()` in the BabylonJS `PhysicsAggregate` class.
+  * @param mesh The `AbstractMesh` whose shape we evaluate to determine the options.
+  * @param objectNode The `Node`, which determines the `PhysicsShapeType` to use.
+  * @param parameters The object in which the calculated parameters are stored.
+  */
+  private addShapeOptions(mesh: AbstractMesh, objectNode: Node.Obj | Node.FromSpaceTemplate | Node.FromBBTemplate, parameters: PhysicsShapeParameters) {
+    // const parameters = params;
+    mesh.computeWorldMatrix(true);
+    const bb = mesh.getRawBoundingInfo().boundingBox;
+    const extents = new Vector3();
+    extents.copyFrom(bb.extendSize);
+    extents.scaleInPlace(2);
+    extents.multiplyInPlace(mesh.absoluteScaling);
+    // In case we had any negative scaling, we need to take the absolute value of the extents.
+    extents.x = Math.abs(extents.x);
+    extents.y = Math.abs(extents.y);
+    extents.z = Math.abs(extents.z);
+
+    const min = new Vector3();
+    min.copyFrom(bb.minimum);
+    min.multiplyInPlace(mesh.absoluteScaling);
+
+    const center = new Vector3();
+    center.copyFrom(bb.center);
+    center.multiplyInPlace(mesh.absoluteScaling);
+    parameters.center = center;
+
+    switch (objectNode.physics?.type) {
+      case 'box': {
+        parameters.extents = extents;
+        parameters.rotation = Quaternion.Identity();
+        break;
+      }
+      case 'sphere': {
+        // TODO
+      }
+      case 'cylinder': {
+        parameters.radius = extents.x / 2;
+        parameters.pointA = new Vector3(0, min.y, 0);
+        parameters.pointB = new Vector3(0, min.y + extents.y, 0);
+      }
+      case 'mesh': {
+        // TODO
+      }
+      case 'none': {
+        // TODO
+      }
+    }
+
+    return parameters;
+  }
+
   private restorePhysicsToObject = (mesh: AbstractMesh,
     objectNode: Node.Obj | Node.FromSpaceTemplate | Node.FromBBTemplate,
     nodeId: string,
@@ -699,24 +752,19 @@ class SceneBinding {
     mesh.setParent(null);
     let physics_mesh = mesh;
 
-   /*
-    * Aggregate params:
-    *     const aggregate = new PhysicsAggregate(mesh, PHYSICS_SHAPE_TYPE_MAPPINGS[objectNode.physics.type], {
-    *  mass: objectNode.physics.mass ? Mass.toGramsValue(objectNode.physics.mass) : 0,
-    *  friction: objectNode.physics.friction ?? 5,
-    *  restitution: objectNode.physics.restitution ?? 0.5,
-    */
-
     /*
      * There are three things you need to setup physics for an object in babylon.js
-     * - First, you need the mesh itself -- that is, the one that the user will see.
+     * - First, you need the mesh: the one that the user will see.
      * - Then, you need to create a physics body for that mesh.
-     * - Finally, you need to set the physics shape -- that is, the shape the engine uses to simulate collisions.
+     * - Finally, you need to set the physics shape which the engine uses to simulate collisions.
      */
 
     /*
-     * This is the PhysicsBody where you set the mass and inertia for your object,
+     * This is the PhysicsBody where you set the mass of your object,
      * as well as determine whether of not it should move.
+     * WARNING: Set inertia manually at your own risk! The physics engine will
+     * calculate it automatically. You will probably get it wrong and things
+     * will behave very strangely.
      */
     const body = new PhysicsBody(
       mesh,
@@ -728,42 +776,25 @@ class SceneBinding {
       // inertia: Vector3.FromArray(objectNode.physics?.inertia ?? [0, 0, 0]),
     });
 
+
     /*
      * Here, we check if the object has a seperate collision body.
      * This should only apply to custom modeled objects.
      */
     if (objectNode.physics?.colliderId) {
       physics_mesh = this.bScene_.getMeshById(objectNode.physics.colliderId);
-      physics_mesh.scaling = RawVector3.toBabylon(objectNode.origin.scale ?? { x: 1, y: 1, z: 1 });
     }
 
     /*
-     * PhysicsShape requires some information to create the shape, depending on exactly what shape you want.
-     * Cylinders and boxes require different parameters, so we handle those seperately.
-     * For more info, see: https://doc.babylonjs.com/features/featuresDeepDive/physics/shapes
+     * Here we set the PhysicsShapeOptions, which tells the engine what kind of
+     * shape we want. It can automatically create a variety of shapes around an
+     * object, including the mesh itself.
+     * See: https://doc.babylonjs.com/features/featuresDeepDive/physics/shapes
      */
-    const scale = RawVector3.toBabylon(objectNode.origin.scale ?? { x: 1, y: 1, z: 1 });
     let parameters: PhysicsShapeParameters = { mesh: physics_mesh as Mesh };
-    let physicsType = objectNode.physics.type;
-
-    // The built-in PhysicsShapeCylinder cannot be distorted on x and z independently for scaling, so instead use the visual mesh
-    if (objectNode.physics.type === 'cylinder') {
-      physicsType = 'mesh';
-    } else if (objectNode.physics.type === 'box') {
-      // The final multiplication by [2, 2, 2] is required to make collision boxes scale correctly
-      const extend = physics_mesh.getBoundingInfo().boundingBox.extendSize.multiply(scale).multiply(new Vector3(2, 2, 2));
-      parameters = {
-        ...parameters,
-        extents: extend,
-      };
-    }
-
-    /*
-     * Here we set the PhysicsShapeOptions, which tells the engine what kind of shape we want.
-     * It knows how to create some shapes automatically, based on the mesh that we gave it above.
-     * For example, it can automatically create a box or a cylinder around an object, or it can use the mesh itself.
-     */
-    const options: PhysicShapeOptions = { type: PHYSICS_SHAPE_TYPE_MAPPINGS[physicsType], parameters };
+    // Notice that we are passing mesh, not physicsMesh here
+    this.addShapeOptions(mesh, objectNode, parameters);
+    const options: PhysicShapeOptions = { type: PHYSICS_SHAPE_TYPE_MAPPINGS[objectNode.physics.type], parameters };
     const shape = new PhysicsShape(options, this.bScene);
     shape.material = {
       friction: objectNode.physics.friction ?? 5,

--- a/src/simulator/babylonBindings/SceneBinding.ts
+++ b/src/simulator/babylonBindings/SceneBinding.ts
@@ -680,7 +680,8 @@ class SceneBinding {
   }[]> = {};
 
   /**
-  * Determine the `PhysicsShapeParameters` for a `Node`. This function is adapted from `_addSizeOptions()` in the BabylonJS `PhysicsAggregate` class.
+  * Determine the `PhysicsShapeParameters` for a `Node`.
+  * This function is adapted from `_addSizeOptions()` in the BabylonJS`PhysicsAggregate` class.
   * @param mesh The `AbstractMesh` whose shape we evaluate to determine the options.
   * @param objectNode The `Node`, which determines the `PhysicsShapeType` to use.
   * @param parameters The object in which the calculated parameters are stored.
@@ -714,18 +715,27 @@ class SceneBinding {
         break;
       }
       case 'sphere': {
-        // TODO
+        if (Math.abs(extents.x - extents.y) <= 0.0001 && Math.abs(extents.x - extents.z) <= 0.0001) {
+          parameters.radius = extents.x / 2;
+        }
+        else {
+          parameters.radius = Math.max(extents.x, extents.y, extents.z);
+        }
+        break;
       }
       case 'cylinder': {
         parameters.radius = extents.x / 2;
         parameters.pointA = new Vector3(0, min.y, 0);
         parameters.pointB = new Vector3(0, min.y + extents.y, 0);
+        break;
       }
       case 'mesh': {
-        // TODO
+        // Nothing to do, we set the mesh in `restorePhysicsToObject`
+        break;
       }
       case 'none': {
-        // TODO
+        // Nothing to do
+        break;
       }
     }
 
@@ -778,7 +788,7 @@ class SceneBinding {
 
 
     /*
-     * Here, we check if the object has a seperate collision body.
+     * Check if the object has a seperate collision body.
      * This should only apply to custom modeled objects.
      */
     if (objectNode.physics?.colliderId) {
@@ -786,7 +796,7 @@ class SceneBinding {
     }
 
     /*
-     * Here we set the PhysicsShapeOptions, which tells the engine what kind of
+     * Set the PhysicsShapeOptions, which tells the engine what kind of
      * shape we want. It can automatically create a variety of shapes around an
      * object, including the mesh itself.
      * See: https://doc.babylonjs.com/features/featuresDeepDive/physics/shapes

--- a/src/simulator/babylonBindings/SceneBinding.ts
+++ b/src/simulator/babylonBindings/SceneBinding.ts
@@ -699,6 +699,14 @@ class SceneBinding {
     mesh.setParent(null);
     let physics_mesh = mesh;
 
+   /*
+    * Aggregate params:
+    *     const aggregate = new PhysicsAggregate(mesh, PHYSICS_SHAPE_TYPE_MAPPINGS[objectNode.physics.type], {
+    *  mass: objectNode.physics.mass ? Mass.toGramsValue(objectNode.physics.mass) : 0,
+    *  friction: objectNode.physics.friction ?? 5,
+    *  restitution: objectNode.physics.restitution ?? 0.5,
+    */
+
     /*
      * There are three things you need to setup physics for an object in babylon.js
      * - First, you need the mesh itself -- that is, the one that the user will see.
@@ -716,8 +724,8 @@ class SceneBinding {
       false,
       this.bScene);
     body.setMassProperties({
-      mass: Mass.toKilogramsValue(objectNode.physics?.mass ?? Mass.grams(0)),
-      inertia: Vector3.FromArray(objectNode.physics?.inertia ?? [0, 0, 0]),
+      mass: objectNode.physics.mass ? Mass.toGramsValue(objectNode.physics.mass) : 0,
+      // inertia: Vector3.FromArray(objectNode.physics?.inertia ?? [0, 0, 0]),
     });
 
     /*
@@ -758,8 +766,8 @@ class SceneBinding {
     const options: PhysicShapeOptions = { type: PHYSICS_SHAPE_TYPE_MAPPINGS[physicsType], parameters };
     const shape = new PhysicsShape(options, this.bScene);
     shape.material = {
-      friction: objectNode.physics.friction ?? 0.2,
-      restitution: objectNode.physics.restitution ?? 0.2,
+      friction: objectNode.physics.friction ?? 5,
+      restitution: objectNode.physics.restitution ?? 0.5,
     };
 
     // Tell the PhysicsBody we created earlier to use this shape

--- a/src/simulator/definitions/nodes/2025gameTableTemplates.ts
+++ b/src/simulator/definitions/nodes/2025gameTableTemplates.ts
@@ -123,8 +123,8 @@ const tacoTemplate: Node.TemplatedNode<Node.Obj> = {
 const CUP_PHYSICS: Node.Physics = {
   colliderId: "collider-box-cup",
   type: 'mesh',
-  restitution: .4,
-  friction: 1,
+  restitution: .1,
+  friction: 0.5,
   mass: Mass.grams(5),
   inertia: [3, 3, 3],
 };

--- a/src/simulator/definitions/scenes/tableBase.ts
+++ b/src/simulator/definitions/scenes/tableBase.ts
@@ -25,8 +25,8 @@ const INNER_FRYER_ORIGIN: ReferenceFramewUnits = {
 };
 
 const GAME_TABLE_ORIGIN: ReferenceFramewUnits = {
-  position: Vector3wUnits.centimeters(0, 0, 0),
-  scale: { x: 100, y: 100, z: 100 },
+  position: Vector3wUnits.centimeters(0, 13, 0),
+  // scale: { x: 100, y: 100, z: 100 },
 };
 
 const LIGHT_ORIGIN: ReferenceFramewUnits = {

--- a/src/state/State/Scene/Node.ts
+++ b/src/state/State/Scene/Node.ts
@@ -49,17 +49,17 @@ namespace Node {
      * Restitution (bounciness) of the object.
      * Defines how much energy is retained after a collision, where zero
      * means none is retained, one means all energy is is retained, and values
-     * greater than one mean that energy is actually gained from the collsion.
+     * greater than one mean that energy is gained from the collsion.
      * Should generally be between zero and one. If undefined, 0.2.
      */
     restitution?: number;
 
     /**
-     * The moment of inertia of the Mesh, represented as a
-     * 3-length vector. Represents how hard to rotate left/right (x),
-     * twisting around (y), and rocking back/forward (z).
-     * WARNING: If undefined, all zeros, which babylonJS
-     * treats as infinite inertia.
+     * The moment of inertia of the Mesh, represented as a 3-length vector.
+     * Represents how hard to rotate left/right (x), twisting around (y), and
+     * rocking back/forward (z). The physics engine calculates this
+     * automatically and it is difficult to get right setting it manually, so
+     * this value is currently ignored.
      */
     inertia?: number[];
 

--- a/static/object_binaries/2025_game_table.glb
+++ b/static/object_binaries/2025_game_table.glb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ecdb3c1051d5da54faa0d7a89593358a9fdcba2a121f5d99cf1739c4db49f94
-size 9353628
+oid sha256:edbe779e516a36c81dbc6d955a329c74554a2109a2ceeeb1de6b4708fc6fde00
+size 9471628


### PR DESCRIPTION
Fixes a bug where the claw would "skewer" objects when trying to grab them, resulting in the robot being unable to put things down. An object's physics initialization now more closely follows the BabylonJS defaults from `PhysicsAggregate`.