### PR TITLE
refactor: use tr for challenge localization strings

### DIFF
--- a/src/simulator/definitions/challenges/archived/jbc10-Solo-Joust.ts
+++ b/src/simulator/definitions/challenges/archived/jbc10-Solo-Joust.ts
@@ -1,14 +1,12 @@
 import Author from '../../../../db/Author';
 import Challenge from '../../../../state/State/Challenge';
 import Expr from '../../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 10' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 10: Solo Joust`,
-  },
+  name: tr('JBC Challenge 10'),
+  description: tr(`Junior Botball Challenge 10: Solo Joust`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -22,18 +20,16 @@ export default {
   events: {
    
     can1Upright: {
-      name: { [LocalizedString.EN_US]: 'Can A Upright' },
-      description: {
-        [LocalizedString.EN_US]: 'Can A upright in a circle',
-      },
+      name: tr('Can A Upright'),
+      description: tr('Can A upright in a circle'),
     },
     leaveStartBox: {
-      name: { [LocalizedString.EN_US]: 'Robot Left Start' },
-      description: { [LocalizedString.EN_US]: 'Robot left starting box' },
+      name: tr('Robot Left Start'),
+      description: tr('Robot left starting box'),
     },
     robotTouchingLine: {
-      name: { [LocalizedString.EN_US]: 'Robot Touching Line B' },
-      description: { [LocalizedString.EN_US]: 'Robot is touching line B' },
+      name: tr('Robot Touching Line B'),
+      description: tr('Robot is touching line B'),
     },
 
   },

--- a/src/simulator/definitions/challenges/archived/jbc10b-Solo-Joust-Jr.ts
+++ b/src/simulator/definitions/challenges/archived/jbc10b-Solo-Joust-Jr.ts
@@ -1,14 +1,12 @@
 import Author from '../../../../db/Author';
 import Challenge from '../../../../state/State/Challenge';
 import Expr from '../../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 10B' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 10B: Solo Joust Jr.`,
-  },
+  name: tr('JBC Challenge 10B'),
+  description: tr(`Junior Botball Challenge 10B: Solo Joust Jr.`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -22,18 +20,16 @@ export default {
   events: {
    
     can1Upright: {
-      name: { [LocalizedString.EN_US]: 'Can A Upright' },
-      description: {
-        [LocalizedString.EN_US]: 'Can A upright in a circle',
-      },
+      name: tr('Can A Upright'),
+      description: tr('Can A upright in a circle'),
     },
     leaveStartBox: {
-      name: { [LocalizedString.EN_US]: 'Robot Left Start' },
-      description: { [LocalizedString.EN_US]: 'Robot left starting box' },
+      name: tr('Robot Left Start'),
+      description: tr('Robot left starting box'),
     },
     robotTouchingLine: {
-      name: { [LocalizedString.EN_US]: 'Robot Touching Line B' },
-      description: { [LocalizedString.EN_US]: 'Robot is touching line B' },
+      name: tr('Robot Touching Line B'),
+      description: tr('Robot is touching line B'),
     },
 
   },

--- a/src/simulator/definitions/challenges/archived/jbc12-Unload-Em.ts
+++ b/src/simulator/definitions/challenges/archived/jbc12-Unload-Em.ts
@@ -1,14 +1,12 @@
 import Author from "../../../../db/Author";
 import Challenge from "../../../../state/State/Challenge";
 import Expr from "../../../../state/State/Challenge/Expr";
-import LocalizedString from "../../../../util/LocalizedString";
 import ProgrammingLanguage from "../../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: "JBC Challenge 12" },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 12: Unload 'Em`,
-  },
+  name: tr("JBC Challenge 12"),
+  description: tr(`Junior Botball Challenge 12: Unload 'Em`),
   author: {
     type: Author.Type.Organization,
     id: "kipr",
@@ -21,29 +19,29 @@ export default {
   defaultLanguage: "c",
   events: {
     can2Upright: {
-      name: { [LocalizedString.EN_US]: "Can 2 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 2 upright" },
+      name: tr("Can 2 Upright"),
+      description: tr("Can 2 upright"),
     },
     can9Upright: {
-      name: { [LocalizedString.EN_US]: "Can 9 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 9 upright" },
+      name: tr("Can 9 Upright"),
+      description: tr("Can 9 upright"),
     },
     can10Upright: {
-      name: { [LocalizedString.EN_US]: "Can 10 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 10 upright" },
+      name: tr("Can 10 Upright"),
+      description: tr("Can 10 upright"),
     },
 
     can2Intersects: {
-      name: { [LocalizedString.EN_US]: "Can 2 Intersects" },
-      description: { [LocalizedString.EN_US]: "Can from green garage intersects circle 2" },
+      name: tr("Can 2 Intersects"),
+      description: tr("Can from green garage intersects circle 2"),
     },
     can9Intersects: {
-      name: { [LocalizedString.EN_US]: "Can 9 Intersects" },
-      description: { [LocalizedString.EN_US]: "Can from blue garage intersects circle 9" },
+      name: tr("Can 9 Intersects"),
+      description: tr("Can from blue garage intersects circle 9"),
     },
     can10Intersects: {
-      name: { [LocalizedString.EN_US]: "Can 10 Intersects" },
-      description: { [LocalizedString.EN_US]: "Can from yellow garage intersects circle 10" },
+      name: tr("Can 10 Intersects"),
+      description: tr("Can from yellow garage intersects circle 10"),
     },
   },
   success: {

--- a/src/simulator/definitions/challenges/archived/jbc13-Clean-the-Mat.ts
+++ b/src/simulator/definitions/challenges/archived/jbc13-Clean-the-Mat.ts
@@ -1,14 +1,12 @@
 import Author from '../../../../db/Author';
 import Challenge from '../../../../state/State/Challenge';
 import Expr from '../../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 13' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 13: Clean the Mat`,
-  },
+  name: tr('JBC Challenge 13'),
+  description: tr(`Junior Botball Challenge 13: Clean the Mat`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,45 +19,45 @@ export default {
   defaultLanguage: 'c',
   events: {
     can2Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 2 Intersects' },
-      description: { [LocalizedString.EN_US]: 'Can 2 intersects chosen garage' },
+      name: tr('Can 2 Intersects'),
+      description: tr('Can 2 intersects chosen garage'),
     },
     can5Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 5 Intersects' },
-      description: { [LocalizedString.EN_US]: 'Can 5 intersects chosen garage' },
+      name: tr('Can 5 Intersects'),
+      description: tr('Can 5 intersects chosen garage'),
     },
     can8Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 8 Intersects' },
-      description: { [LocalizedString.EN_US]: 'Can 8 intersects chosen garage' },
+      name: tr('Can 8 Intersects'),
+      description: tr('Can 8 intersects chosen garage'),
     },
     can10Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 10 Intersects' },
-      description: { [LocalizedString.EN_US]: 'Can 10 intersects chosen garage' },
+      name: tr('Can 10 Intersects'),
+      description: tr('Can 10 intersects chosen garage'),
     },
     can11Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 11 Intersects' },
-      description: { [LocalizedString.EN_US]: 'Can 11 intersects chosen garage' },
+      name: tr('Can 11 Intersects'),
+      description: tr('Can 11 intersects chosen garage'),
     },
 
     can2Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 2 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 2 upright in chosen garage' },
+      name: tr('Can 2 Upright'),
+      description: tr('Can 2 upright in chosen garage'),
     },
     can5Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 5 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 5 upright in achosen garage' },
+      name: tr('Can 5 Upright'),
+      description: tr('Can 5 upright in achosen garage'),
     },
     can8Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 8 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 8 upright in chosen garage' },
+      name: tr('Can 8 Upright'),
+      description: tr('Can 8 upright in chosen garage'),
     },
     can10Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 10 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 10 upright in chosen garage' },
+      name: tr('Can 10 Upright'),
+      description: tr('Can 10 upright in chosen garage'),
     },
     can11Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 11 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 11 upright in chosen garage' },
+      name: tr('Can 11 Upright'),
+      description: tr('Can 11 upright in chosen garage'),
     },
 
 

--- a/src/simulator/definitions/challenges/archived/jbc15b-Bump-Bump.ts
+++ b/src/simulator/definitions/challenges/archived/jbc15b-Bump-Bump.ts
@@ -1,14 +1,12 @@
 import Author from '../../../../db/Author';
 import Challenge from '../../../../state/State/Challenge';
 import Expr from '../../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 15B' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 15B: Bump Bump`,
-  },
+  name: tr('JBC Challenge 15B'),
+  description: tr(`Junior Botball Challenge 15B: Bump Bump`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,25 +19,17 @@ export default {
   defaultLanguage: 'c',
   events: {
     driveForwardTouch: {
-      name: { [LocalizedString.EN_US]: 'Robot Forward Touch' },
-      description: {
-        [LocalizedString.EN_US]:
-          'Robot drove forward and touched ream of paper',
-      },
+      name: tr('Robot Forward Touch'),
+      description: tr('Robot drove forward and touched ream of paper'),
     },
 
     driveBackwardTouch: {
-      name: { [LocalizedString.EN_US]: 'Robot Backward Touch' },
-      description: {
-        [LocalizedString.EN_US]:
-          'Robot drove backward and touched ream of paper',
-      },
+      name: tr('Robot Backward Touch'),
+      description: tr('Robot drove backward and touched ream of paper'),
     },
     driveForward2: {
-      name: { [LocalizedString.EN_US]: 'Robot Forward Circle 2' },
-      description: {
-        [LocalizedString.EN_US]: 'Robot drove forward to circle 2',
-      },
+      name: tr('Robot Forward Circle 2'),
+      description: tr('Robot drove forward to circle 2'),
     },
   },
   success: {

--- a/src/simulator/definitions/challenges/archived/jbc17b-Walk-the-Line-2.ts
+++ b/src/simulator/definitions/challenges/archived/jbc17b-Walk-the-Line-2.ts
@@ -1,14 +1,12 @@
 import Author from '../../../../db/Author';
 import Challenge from '../../../../state/State/Challenge';
 import Expr from '../../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 17B' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 17B: Walk the Line II`,
-  },
+  name: tr('JBC Challenge 17B'),
+  description: tr(`Junior Botball Challenge 17B: Walk the Line II`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,11 +19,8 @@ export default {
   defaultLanguage: 'c',
   events: {
     lineFollow: {
-      name: { [LocalizedString.EN_US]: 'Robot Walks the Line' },
-      description: {
-        [LocalizedString.EN_US]:
-          'Robot uses reflectance sensor to follow the black line until the Blue line',
-      },
+      name: tr('Robot Walks the Line'),
+      description: tr('Robot uses reflectance sensor to follow the black line until the Blue line'),
     },
   },
   success: {

--- a/src/simulator/definitions/challenges/archived/jbc20-Rescue-the-Cans.ts
+++ b/src/simulator/definitions/challenges/archived/jbc20-Rescue-the-Cans.ts
@@ -1,14 +1,12 @@
 import Author from '../../../../db/Author';
 import Challenge from '../../../../state/State/Challenge';
 import Expr from '../../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 20' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 20: Rescue the Cans`,
-  },
+  name: tr('JBC Challenge 20'),
+  description: tr(`Junior Botball Challenge 20: Rescue the Cans`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -22,53 +20,37 @@ export default {
   events: {
     
     can2Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 2 Upright' },
-      description: {
-        [LocalizedString.EN_US]: 'Can 2 is upright',
-      },
+      name: tr('Can 2 Upright'),
+      description: tr('Can 2 is upright'),
     },
     can9Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 9 Upright' },
-      description: {
-        [LocalizedString.EN_US]: 'Can 9 is upright',
-      },
+      name: tr('Can 9 Upright'),
+      description: tr('Can 9 is upright'),
     },
     can10Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 10 Upright' },
-      description: {
-        [LocalizedString.EN_US]: 'Can 10 is upright',
-      },
+      name: tr('Can 10 Upright'),
+      description: tr('Can 10 is upright'),
     },
     can12Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 12 Upright' },
-      description: {
-        [LocalizedString.EN_US]: 'Can 12 is upright',
-      },
+      name: tr('Can 12 Upright'),
+      description: tr('Can 12 is upright'),
     },
 
     can9Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 9 Intersects' },
-      description: {
-        [LocalizedString.EN_US]: 'Can 9 rescued intersecting paper ream',
-      },
+      name: tr('Can 9 Intersects'),
+      description: tr('Can 9 rescued intersecting paper ream'),
     },
     can2Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 2 Intersects' },
-      description: {
-        [LocalizedString.EN_US]: 'Can 2 rescued intersecting paper ream',
-      },
+      name: tr('Can 2 Intersects'),
+      description: tr('Can 2 rescued intersecting paper ream'),
     },
     can10Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 10 Intersects' },
-      description: {
-        [LocalizedString.EN_US]: 'Can 10 rescued intersecting paper ream',
-      },
+      name: tr('Can 10 Intersects'),
+      description: tr('Can 10 rescued intersecting paper ream'),
     },
     can12Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 12 Intersects' },
-      description: {
-        [LocalizedString.EN_US]: 'Can 12 rescued intersecting paper ream',
-      },
+      name: tr('Can 12 Intersects'),
+      description: tr('Can 12 rescued intersecting paper ream'),
     },
   },
   success: {

--- a/src/simulator/definitions/challenges/archived/jbc21-Foot-Tall.ts
+++ b/src/simulator/definitions/challenges/archived/jbc21-Foot-Tall.ts
@@ -1,14 +1,12 @@
 import Author from '../../../../db/Author';
 import Challenge from '../../../../state/State/Challenge';
 import Expr from '../../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 21' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 21: Foot Tall`,
-  },
+  name: tr('JBC Challenge 21'),
+  description: tr(`Junior Botball Challenge 21: Foot Tall`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,10 +19,8 @@ export default {
   defaultLanguage: 'c',
   events: {
     footTallMark: {
-      name: { [LocalizedString.EN_US]: 'Can 9 Lifted' },
-      description: {
-        [LocalizedString.EN_US]: 'Can 9 Lifted a Foot Tall',
-      },
+      name: tr('Can 9 Lifted'),
+      description: tr('Can 9 Lifted a Foot Tall'),
     },
   },
   success: {

--- a/src/simulator/definitions/challenges/archived/jbc2b-Ring-Around-the-Cans-Sr.ts
+++ b/src/simulator/definitions/challenges/archived/jbc2b-Ring-Around-the-Cans-Sr.ts
@@ -1,14 +1,12 @@
 import Author from "../../../../db/Author";
 import Challenge from "../../../../state/State/Challenge";
 import Expr from "../../../../state/State/Challenge/Expr";
-import LocalizedString from "../../../../util/LocalizedString";
 import ProgrammingLanguage from "../../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: "JBC Challenge 2B" },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 2B: Ring Around the Cans, Sr.`,
-  },
+  name: tr("JBC Challenge 2B"),
+  description: tr(`Junior Botball Challenge 2B: Ring Around the Cans, Sr.`),
   author: {
     type: Author.Type.Organization,
     id: "kipr",
@@ -21,72 +19,66 @@ export default {
   defaultLanguage: "c",
   events: {
     can10Touched: {
-      name: { [LocalizedString.EN_US]: "Can 10 Touched" },
-      description: { [LocalizedString.EN_US]: "Can 10 touched" },
+      name: tr("Can 10 Touched"),
+      description: tr("Can 10 touched"),
     },
     can11Touched: {
-      name: { [LocalizedString.EN_US]: "Can 11 Touched" },
-      description: { [LocalizedString.EN_US]: "Can 11 touched" },
+      name: tr("Can 11 Touched"),
+      description: tr("Can 11 touched"),
     },
     can12Touched: {
-      name: { [LocalizedString.EN_US]: "Can 12 Touched" },
-      description: { [LocalizedString.EN_US]: "Can 12 touched" },
+      name: tr("Can 12 Touched"),
+      description: tr("Can 12 touched"),
     },
 
     can10Intersects: {
-      name: { [LocalizedString.EN_US]: "Can 10 Intersects" },
-      description: { [LocalizedString.EN_US]: "Can 10 intersects circle 10" },
+      name: tr("Can 10 Intersects"),
+      description: tr("Can 10 intersects circle 10"),
     },
     can11Intersects: {
-      name: { [LocalizedString.EN_US]: "Can 11 Intersects" },
-      description: { [LocalizedString.EN_US]: "Can 11 intersects circle 11" },
+      name: tr("Can 11 Intersects"),
+      description: tr("Can 11 intersects circle 11"),
     },
     can12Intersects: {
-      name: { [LocalizedString.EN_US]: "Can 12 Intersects" },
-      description: { [LocalizedString.EN_US]: "Can 12 intersects circle 12" },
+      name: tr("Can 12 Intersects"),
+      description: tr("Can 12 intersects circle 12"),
     },
 
     can10Upright: {
-      name: { [LocalizedString.EN_US]: "Can 10 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 10 upright on circle 10" },
+      name: tr("Can 10 Upright"),
+      description: tr("Can 10 upright on circle 10"),
     },
     can11Upright: {
-      name: { [LocalizedString.EN_US]: "Can 11 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 11 upright on circle 11" },
+      name: tr("Can 11 Upright"),
+      description: tr("Can 11 upright on circle 11"),
     },
     can12Upright: {
-      name: { [LocalizedString.EN_US]: "Can 12 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 12 upright on circle 12" },
+      name: tr("Can 12 Upright"),
+      description: tr("Can 12 upright on circle 12"),
     },
 
     leaveStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot Left Start" },
-      description: { [LocalizedString.EN_US]: "Robot left starting box" },
+      name: tr("Robot Left Start"),
+      description: tr("Robot left starting box"),
     },
     returnStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot Rentered Start" },
-      description: { [LocalizedString.EN_US]: "Robot reentered starting box" },
+      name: tr("Robot Rentered Start"),
+      description: tr("Robot reentered starting box"),
     },
 
     rightSide: {
-      name: { [LocalizedString.EN_US]: "Robot Passed Right Side" },
-      description: {
-        [LocalizedString.EN_US]: "Robot passed right side of can 12",
-      },
+      name: tr("Robot Passed Right Side"),
+      description: tr("Robot passed right side of can 12"),
     },
 
     topSide: {
-      name: { [LocalizedString.EN_US]: "Robot Passed Top Side" },
-      description: {
-        [LocalizedString.EN_US]: "Robot passed top side of can 11",
-      },
+      name: tr("Robot Passed Top Side"),
+      description: tr("Robot passed top side of can 11"),
     },
 
     leftSide: {
-      name: { [LocalizedString.EN_US]: "Robot Passed left Side" },
-      description: {
-        [LocalizedString.EN_US]: "Robot passed left side of can 10",
-      },
+      name: tr("Robot Passed left Side"),
+      description: tr("Robot passed left side of can 10"),
     },
   },
   success: {

--- a/src/simulator/definitions/challenges/archived/jbc2c-Back-It-Up.ts
+++ b/src/simulator/definitions/challenges/archived/jbc2c-Back-It-Up.ts
@@ -1,14 +1,12 @@
 import Author from "../../../../db/Author";
 import Challenge from "../../../../state/State/Challenge";
 import Expr from "../../../../state/State/Challenge/Expr";
-import LocalizedString from "../../../../util/LocalizedString";
 import ProgrammingLanguage from "../../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: "JBC Challenge 2C" },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 2C: Back It Up`,
-  },
+  name: tr("JBC Challenge 2C"),
+  description: tr(`Junior Botball Challenge 2C: Back It Up`),
   author: {
     type: Author.Type.Organization,
     id: "kipr",
@@ -21,48 +19,42 @@ export default {
   defaultLanguage: "c",
   events: {
     can6Intersects: {
-      name: { [LocalizedString.EN_US]: "Can 6 Intersects" },
-      description: { [LocalizedString.EN_US]: "Can 6 intersects circle 6" },
+      name: tr("Can 6 Intersects"),
+      description: tr("Can 6 intersects circle 6"),
     },
 
     can6Upright: {
-      name: { [LocalizedString.EN_US]: "Can 6 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 6 upright on circle 6" },
+      name: tr("Can 6 Upright"),
+      description: tr("Can 6 upright on circle 6"),
     },
 
     leaveStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot Left Start" },
-      description: { [LocalizedString.EN_US]: "Robot left starting box" },
+      name: tr("Robot Left Start"),
+      description: tr("Robot left starting box"),
     },
     returnStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot Rentered Start" },
-      description: { [LocalizedString.EN_US]: "Robot reentered starting box" },
+      name: tr("Robot Rentered Start"),
+      description: tr("Robot reentered starting box"),
     },
 
     driveBackwards: {
-      name: { [LocalizedString.EN_US]: "Robot Driving Backwards" },
-      description: { [LocalizedString.EN_US]: "Robot is driving backwards" },
+      name: tr("Robot Driving Backwards"),
+      description: tr("Robot is driving backwards"),
     },
 
     rightSide: {
-      name: { [LocalizedString.EN_US]: "Robot Passed Right Side" },
-      description: {
-        [LocalizedString.EN_US]: "Robot passed right side of can 6",
-      },
+      name: tr("Robot Passed Right Side"),
+      description: tr("Robot passed right side of can 6"),
     },
 
     topSide: {
-      name: { [LocalizedString.EN_US]: "Robot Passed Top Side" },
-      description: {
-        [LocalizedString.EN_US]: "Robot passed top side of can 6",
-      },
+      name: tr("Robot Passed Top Side"),
+      description: tr("Robot passed top side of can 6"),
     },
 
     leftSide: {
-      name: { [LocalizedString.EN_US]: "Robot Passed left Side" },
-      description: {
-        [LocalizedString.EN_US]: "Robot passed left side of can 6",
-      },
+      name: tr("Robot Passed left Side"),
+      description: tr("Robot passed left side of can 6"),
     },
   },
   success: {

--- a/src/simulator/definitions/challenges/archived/jbc2d-Ring-Around-the-Can-and-Back-It-Up.ts
+++ b/src/simulator/definitions/challenges/archived/jbc2d-Ring-Around-the-Can-and-Back-It-Up.ts
@@ -1,14 +1,12 @@
 import Author from '../../../../db/Author';
 import Challenge from '../../../../state/State/Challenge';
 import Expr from '../../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 2D' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 2C: Ring Around the Can and Back It Up`,
-  },
+  name: tr('JBC Challenge 2D'),
+  description: tr(`Junior Botball Challenge 2C: Ring Around the Can and Back It Up`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,59 +19,47 @@ export default {
   defaultLanguage: 'c',
   events: {
     can6Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 6 Intersects' },
-      description: { [LocalizedString.EN_US]: 'Can 6 intersects circle 6' },
+      name: tr('Can 6 Intersects'),
+      description: tr('Can 6 intersects circle 6'),
     },
 
     can6Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 6 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 6 upright on circle 6' },
+      name: tr('Can 6 Upright'),
+      description: tr('Can 6 upright on circle 6'),
     },
 
     returnStartBox1: {
-      name: { [LocalizedString.EN_US]: 'Robot Rentered Start 1' },
-      description: {
-        [LocalizedString.EN_US]:
-          'Robot reentered starting box after going forwards',
-      },
+      name: tr('Robot Rentered Start 1'),
+      description: tr('Robot reentered starting box after going forwards'),
     },
 
     returnStartBox2: {
-      name: { [LocalizedString.EN_US]: 'Robot Rentered Start 2' },
-      description: {
-        [LocalizedString.EN_US]:
-          'Robot reentered starting box after going backwards',
-      },
+      name: tr('Robot Rentered Start 2'),
+      description: tr('Robot reentered starting box after going backwards'),
     },
 
     driveBackwards: {
-      name: { [LocalizedString.EN_US]: 'Robot Driving Backwards' },
-      description: { [LocalizedString.EN_US]: 'Robot is driving backwards' },
+      name: tr('Robot Driving Backwards'),
+      description: tr('Robot is driving backwards'),
     },
     driveForwards: {
-      name: { [LocalizedString.EN_US]: 'Robot Driving Forwards' },
-      description: { [LocalizedString.EN_US]: 'Robot is driving forwards' },
+      name: tr('Robot Driving Forwards'),
+      description: tr('Robot is driving forwards'),
     },
 
     rightSide: {
-      name: { [LocalizedString.EN_US]: 'Robot Passed Right Side' },
-      description: {
-        [LocalizedString.EN_US]: 'Robot passed right side of can 6',
-      },
+      name: tr('Robot Passed Right Side'),
+      description: tr('Robot passed right side of can 6'),
     },
 
     topSide: {
-      name: { [LocalizedString.EN_US]: 'Robot Passed Top Side' },
-      description: {
-        [LocalizedString.EN_US]: 'Robot passed top side of can 6',
-      },
+      name: tr('Robot Passed Top Side'),
+      description: tr('Robot passed top side of can 6'),
     },
 
     leftSide: {
-      name: { [LocalizedString.EN_US]: 'Robot Passed left Side' },
-      description: {
-        [LocalizedString.EN_US]: 'Robot passed left side of can 6',
-      },
+      name: tr('Robot Passed left Side'),
+      description: tr('Robot passed left side of can 6'),
     },
   },
   success: {

--- a/src/simulator/definitions/challenges/archived/jbc4b-Barrel-Racing.ts
+++ b/src/simulator/definitions/challenges/archived/jbc4b-Barrel-Racing.ts
@@ -1,14 +1,12 @@
 import Author from "../../../../db/Author";
 import Challenge from "../../../../state/State/Challenge";
 import Expr from "../../../../state/State/Challenge/Expr";
-import LocalizedString from "../../../../util/LocalizedString";
 import ProgrammingLanguage from "../../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: "JBC Challenge 4B" },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 4B: Barrel Racing`,
-  },
+  name: tr("JBC Challenge 4B"),
+  description: tr(`Junior Botball Challenge 4B: Barrel Racing`),
   author: {
     type: Author.Type.Organization,
     id: "kipr",
@@ -21,57 +19,51 @@ export default {
   defaultLanguage: "c",
   events: {
     can5Intersects: {
-      name: { [LocalizedString.EN_US]: "Can 5 Intersects" },
-      description: { [LocalizedString.EN_US]: "Can 5 intersects circle 5" },
+      name: tr("Can 5 Intersects"),
+      description: tr("Can 5 intersects circle 5"),
     },
     can8Intersects: {
-      name: { [LocalizedString.EN_US]: "Can 8 Intersects" },
-      description: { [LocalizedString.EN_US]: "Can 8 intersects circle 8" },
+      name: tr("Can 8 Intersects"),
+      description: tr("Can 8 intersects circle 8"),
     },
     can9Intersects: {
-      name: { [LocalizedString.EN_US]: "Can 9 Intersects" },
-      description: { [LocalizedString.EN_US]: "Can 9 intersects circle 9" },
+      name: tr("Can 9 Intersects"),
+      description: tr("Can 9 intersects circle 9"),
     },
 
     can5Upright: {
-      name: { [LocalizedString.EN_US]: "Can 5 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 5 upright on circle 5" },
+      name: tr("Can 5 Upright"),
+      description: tr("Can 5 upright on circle 5"),
     },
     can8Upright: {
-      name: { [LocalizedString.EN_US]: "Can 8 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 8 upright on circle 8" },
+      name: tr("Can 8 Upright"),
+      description: tr("Can 8 upright on circle 8"),
     },
     can9Upright: {
-      name: { [LocalizedString.EN_US]: "Can 9 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 9 upright on circle 9" },
+      name: tr("Can 9 Upright"),
+      description: tr("Can 9 upright on circle 9"),
     },
 
     leaveStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot Left Start" },
-      description: { [LocalizedString.EN_US]: "Robot left starting box" },
+      name: tr("Robot Left Start"),
+      description: tr("Robot left starting box"),
     },
     returnStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot Rentered Start" },
-      description: { [LocalizedString.EN_US]: "Robot reentered starting box" },
+      name: tr("Robot Rentered Start"),
+      description: tr("Robot reentered starting box"),
     },
 
     clockwise8: {
-      name: { [LocalizedString.EN_US]: "Can 8 Clockwise" },
-      description: {
-        [LocalizedString.EN_US]: "Robot drove clockwise around can 8",
-      },
+      name: tr("Can 8 Clockwise"),
+      description: tr("Robot drove clockwise around can 8"),
     },
     counterClockwise5: {
-      name: { [LocalizedString.EN_US]: "Can 5 Counter Clockwise" },
-      description: {
-        [LocalizedString.EN_US]: "Robot drove counter clockwise around can 5",
-      },
+      name: tr("Can 5 Counter Clockwise"),
+      description: tr("Robot drove counter clockwise around can 5"),
     },
     counterClockwise9: {
-      name: { [LocalizedString.EN_US]: "Can 9 Counter Clockwise" },
-      description: {
-        [LocalizedString.EN_US]: "Robot drove counter clockwise around can 9",
-      },
+      name: tr("Can 9 Counter Clockwise"),
+      description: tr("Robot drove counter clockwise around can 9"),
     },
   },
   success: {

--- a/src/simulator/definitions/challenges/archived/jbc8b-Serpentine-Jr.ts
+++ b/src/simulator/definitions/challenges/archived/jbc8b-Serpentine-Jr.ts
@@ -1,14 +1,12 @@
 import Author from '../../../../db/Author';
 import Challenge from '../../../../state/State/Challenge';
 import Expr from '../../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 8B' },
-  description: {
-    [LocalizedString.EN_US]: 'Junior Botball Challenge 8B: Serpentine Jr.',
-  },
+  name: tr('JBC Challenge 8B'),
+  description: tr('Junior Botball Challenge 8B: Serpentine Jr.'),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,28 +19,28 @@ export default {
   defaultLanguage: 'c',
   events: {
     start: {
-      name: { [LocalizedString.EN_US]: 'Robot Begins In start' },
-      description: { [LocalizedString.EN_US]: 'Robot begins in starting box' },
+      name: tr('Robot Begins In start'),
+      description: tr('Robot begins in starting box'),
     },
     passed1: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched Circle 1' },
-      description: { [LocalizedString.EN_US]: 'Robot passed through circle 1' },
+      name: tr('Robot Touched Circle 1'),
+      description: tr('Robot passed through circle 1'),
     },
     passed2: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched Circle 2' },
-      description: { [LocalizedString.EN_US]: 'Robot passed through circle 2' },
+      name: tr('Robot Touched Circle 2'),
+      description: tr('Robot passed through circle 2'),
     },
     passed3: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched Circle 3' },
-      description: { [LocalizedString.EN_US]: 'Robot passed through circle 3' },
+      name: tr('Robot Touched Circle 3'),
+      description: tr('Robot passed through circle 3'),
     },
     passed4: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched Circle 4' },
-      description: { [LocalizedString.EN_US]: 'Robot passed through circle 4' },
+      name: tr('Robot Touched Circle 4'),
+      description: tr('Robot passed through circle 4'),
     },
     passed5: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched Circle 5' },
-      description: { [LocalizedString.EN_US]: 'Robot passed through circle 5' },
+      name: tr('Robot Touched Circle 5'),
+      description: tr('Robot passed through circle 5'),
     },
   },
   success: {

--- a/src/simulator/definitions/challenges/archived/test.ts
+++ b/src/simulator/definitions/challenges/archived/test.ts
@@ -1,12 +1,12 @@
 import Author from '../../../../db/Author';
 import Challenge from '../../../../state/State/Challenge';
 import Expr from '../../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'Test' },
-  description: { [LocalizedString.EN_US]: 'Test' },
+  name: tr('Test'),
+  description: tr('Test'),
   author: {
     type: Author.Type.Organization,
     id: 'kipr'
@@ -19,12 +19,12 @@ export default {
   defaultLanguage: 'c',
   events: {
     a: {
-      name: { [LocalizedString.EN_US]: 'A' },
-      description: { [LocalizedString.EN_US]: 'A' },
+      name: tr('A'),
+      description: tr('A'),
     },
     b: {
-      name: { [LocalizedString.EN_US]: 'B' },
-      description: { [LocalizedString.EN_US]: 'B' },
+      name: tr('B'),
+      description: tr('B'),
     }
   },
   success: {

--- a/src/simulator/definitions/challenges/jbc0-Drive-Straight.ts
+++ b/src/simulator/definitions/challenges/jbc0-Drive-Straight.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 0' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 0: Drive Straight`,
-  },
+  name: tr('JBC Challenge 0'),
+  description: tr(`Junior Botball Challenge 0: Drive Straight`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,24 +19,24 @@ export default {
   defaultLanguage: 'c',
   events: {
     inStartBox: {
-      name: { [LocalizedString.EN_US]: 'In Start Box' },
-      description: { [LocalizedString.EN_US]: 'Robot is in the start box' },
+      name: tr('In Start Box'),
+      description: tr('Robot is in the start box'),
     },
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: 'Not In Start Box' },
-      description: { [LocalizedString.EN_US]: 'Robot is not in the start box' },
+      name: tr('Not In Start Box'),
+      description: tr('Robot is not in the start box'),
     },
     robotTouchingLine: {
-      name: { [LocalizedString.EN_US]: 'Robot Touching Line B' },
-      description: { [LocalizedString.EN_US]: 'Robot is touching line B' },
+      name: tr('Robot Touching Line B'),
+      description: tr('Robot is touching line B'),
     },
     reachedEnd: {
-      name: { [LocalizedString.EN_US]: 'Robot Reached End' },
-      description: { [LocalizedString.EN_US]: 'Robot reached the end of the mat' },
+      name: tr('Robot Reached End'),
+      description: tr('Robot reached the end of the mat'),
     },
     offMat: {
-      name: { [LocalizedString.EN_US]: 'Robot Off Mat' },
-      description: { [LocalizedString.EN_US]: 'Robot left the mat' },
+      name: tr('Robot Off Mat'),
+      description: tr('Robot left the mat'),
     },
   },
   success: {
@@ -111,21 +109,21 @@ export default {
   successGoals: [
     {
       exprId: 'startedInStartBoxOnce',
-      name: { [LocalizedString.EN_US]: 'Start in the Start Box' },
+      name: tr('Start in the Start Box'),
     },
     {
       exprId: 'reachedEnd',
-      name: { [LocalizedString.EN_US]: 'Reach the end of the mat' },
+      name: tr('Reach the end of the mat'),
     },
   ],
   failureGoals: [
     {
       exprId: 'robotTouchingLineOnce',
-      name: { [LocalizedString.EN_US]: 'Wheels do not touch line B' },
+      name: tr('Wheels do not touch line B'),
     },
     {
       exprId: 'offMatOnce',
-      name: { [LocalizedString.EN_US]: 'Do not drive off the mat' },
+      name: tr('Do not drive off the mat'),
     },
   ],
   sceneId: 'jbc0',

--- a/src/simulator/definitions/challenges/jbc1-Tag-Youre-It.ts
+++ b/src/simulator/definitions/challenges/jbc1-Tag-Youre-It.ts
@@ -1,12 +1,12 @@
 import Author from "../../../db/Author";
 import Challenge from "../../../state/State/Challenge";
 import Expr from "../../../state/State/Challenge/Expr";
-import LocalizedString from "../../../util/LocalizedString";
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 1' },
-  description: { [LocalizedString.EN_US]: `Junior Botball Challenge 1: Tag, You're it!` },
+  name: tr('JBC Challenge 1'),
+  description: tr(`Junior Botball Challenge 1: Tag, You're it!`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr'
@@ -19,24 +19,24 @@ export default {
   defaultLanguage: 'c',
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: 'Robot not in Start Box' },
-      description: { [LocalizedString.EN_US]: 'Robot not in start box' },
+      name: tr('Robot not in Start Box'),
+      description: tr('Robot not in start box'),
     },
     can9Touched: {
-      name: { [LocalizedString.EN_US]: 'Can 9 Touched' },
-      description: { [LocalizedString.EN_US]: 'Can A touched' },
+      name: tr('Can 9 Touched'),
+      description: tr('Can A touched'),
     },
     can9Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 9 Intersects' },
-      description: { [LocalizedString.EN_US]: 'Can 9 intersects circle 9' },
+      name: tr('Can 9 Intersects'),
+      description: tr('Can 9 intersects circle 9'),
     },
     can9Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 9 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 9 upright on circle 9' },
+      name: tr('Can 9 Upright'),
+      description: tr('Can 9 upright on circle 9'),
     },
     returnStartBox: {
-      name: { [LocalizedString.EN_US]: 'Robot Rentered Start' },
-      description: { [LocalizedString.EN_US]: 'Robot reentered starting box' },
+      name: tr('Robot Rentered Start'),
+      description: tr('Robot reentered starting box'),
     },
   },
   success: {
@@ -110,25 +110,25 @@ export default {
   successGoals: [
     {
       exprId: 'inStartBoxOnce',
-      name: { [LocalizedString.EN_US]: 'Start in the Start Box' },
+      name: tr('Start in the Start Box'),
     },
     {
       exprId: 'can9Touched',
-      name: { [LocalizedString.EN_US]: 'Touch Can 9' },
+      name: tr('Touch Can 9'),
     },
     {
       exprId: 'returnStartBoxOnce',
-      name: { [LocalizedString.EN_US]: 'Return to the Start Box' },
+      name: tr('Return to the Start Box'),
     },
   ],
   failureGoals: [
     {
       exprId: 'can9NotIntersects',
-      name: { [LocalizedString.EN_US]: 'Can 9 not in circle 9' },
+      name: tr('Can 9 not in circle 9'),
     },
     {
       exprId: 'can9NotUpright',
-      name: { [LocalizedString.EN_US]: 'Can 9 not upright' },
+      name: tr('Can 9 not upright'),
     },
   ],
   sceneId: 'jbc1',

--- a/src/simulator/definitions/challenges/jbc10-Chopped.ts
+++ b/src/simulator/definitions/challenges/jbc10-Chopped.ts
@@ -1,14 +1,12 @@
 import Author from "../../../db/Author";
 import Challenge from "../../../state/State/Challenge";
 import Expr from "../../../state/State/Challenge/Expr";
-import LocalizedString from "../../../util/LocalizedString";
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: "JBC Challenge 10" },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 10: Chopped`,
-  },
+  name: tr("JBC Challenge 10"),
+  description: tr(`Junior Botball Challenge 10: Chopped`),
   author: {
     type: Author.Type.Organization,
     id: "kipr",
@@ -21,16 +19,16 @@ export default {
   defaultLanguage: "c",
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot not in Start Box" },
-      description: { [LocalizedString.EN_US]: "Robot not in start box" },
+      name: tr("Robot not in Start Box"),
+      description: tr("Robot not in start box"),
     },
     waitedToChop: {
-      name: { [LocalizedString.EN_US]: "Waited to Chop" },
-      description: { [LocalizedString.EN_US]: "Robot waited to chop" },
+      name: tr("Waited to Chop"),
+      description: tr("Robot waited to chop"),
     },
     can7Upright: {
-      name: { [LocalizedString.EN_US]: "Can 7 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 7 upright" },
+      name: tr("Can 7 Upright"),
+      description: tr("Can 7 upright"),
     },
   },
   success: {
@@ -76,9 +74,9 @@ export default {
     rootId: "completion",
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'waitedToChop', name: { [LocalizedString.EN_US]: 'Wait before chopping' } },
-    { exprId: 'can7NotUpright', name: { [LocalizedString.EN_US]: 'Knock over can 7' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'waitedToChop', name: tr('Wait before chopping') },
+    { exprId: 'can7NotUpright', name: tr('Knock over can 7') },
   ],
   sceneId: "jbc10",
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc11-Making-Waves.ts
+++ b/src/simulator/definitions/challenges/jbc11-Making-Waves.ts
@@ -1,14 +1,12 @@
 import Author from "../../../db/Author";
 import Challenge from "../../../state/State/Challenge";
 import Expr from "../../../state/State/Challenge/Expr";
-import LocalizedString from "../../../util/LocalizedString";
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: "JBC Challenge 11" },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 11: Making Waves`,
-  },
+  name: tr("JBC Challenge 11"),
+  description: tr(`Junior Botball Challenge 11: Making Waves`),
   author: {
     type: Author.Type.Organization,
     id: "kipr",
@@ -21,28 +19,28 @@ export default {
   defaultLanguage: "c",
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot not in Start Box" },
-      description: { [LocalizedString.EN_US]: "Robot not in start box" },
+      name: tr("Robot not in Start Box"),
+      description: tr("Robot not in start box"),
     },
     wave: {
-      name: { [LocalizedString.EN_US]: "Robot Waved" },
-      description: { [LocalizedString.EN_US]: "Robot waved" },
+      name: tr("Robot Waved"),
+      description: tr("Robot waved"),
     },
     circle3Touched: {
-      name: { [LocalizedString.EN_US]: "Circle 3 Touched" },
-      description: { [LocalizedString.EN_US]: "Circle 3 touched" },
+      name: tr("Circle 3 Touched"),
+      description: tr("Circle 3 touched"),
     },
     circle6Touched: {
-      name: { [LocalizedString.EN_US]: "Circle 6 Touched" },
-      description: { [LocalizedString.EN_US]: "Circle 6 touched" },
+      name: tr("Circle 6 Touched"),
+      description: tr("Circle 6 touched"),
     },
     circle9Touched: {
-      name: { [LocalizedString.EN_US]: "Circle 9 Touched" },
-      description: { [LocalizedString.EN_US]: "Circle 9 touched" },
+      name: tr("Circle 9 Touched"),
+      description: tr("Circle 9 touched"),
     },
     circle12Touched: {
-      name: { [LocalizedString.EN_US]: "Circle 12 Touched" },
-      description: { [LocalizedString.EN_US]: "Circle 12 touched" },
+      name: tr("Circle 12 Touched"),
+      description: tr("Circle 12 touched"),
     },
   },
   success: {
@@ -144,11 +142,11 @@ export default {
     rootId: "completion",
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'circle3WavedOnce', name: { [LocalizedString.EN_US]: 'Wave at circle 3' } },
-    { exprId: 'circle6WavedOnce', name: { [LocalizedString.EN_US]: 'Wave at circle 6' } },
-    { exprId: 'circle9WavedOnce', name: { [LocalizedString.EN_US]: 'Wave at circle 9' } },
-    { exprId: 'circle12WavedOnce', name: { [LocalizedString.EN_US]: 'Wave at circle 12' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'circle3WavedOnce', name: tr('Wave at circle 3') },
+    { exprId: 'circle6WavedOnce', name: tr('Wave at circle 6') },
+    { exprId: 'circle9WavedOnce', name: tr('Wave at circle 9') },
+    { exprId: 'circle12WavedOnce', name: tr('Wave at circle 12') },
   ],
   sceneId: "jbc11",
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc12-Add-It-Up.ts
+++ b/src/simulator/definitions/challenges/jbc12-Add-It-Up.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 12' },
-  description: {
-    [LocalizedString.EN_US]: 'Junior Botball Challenge 12: Add It Up',
-  },
+  name: tr('JBC Challenge 12'),
+  description: tr('Junior Botball Challenge 12: Add It Up'),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,12 +19,12 @@ export default {
   defaultLanguage: 'c',
   events: {
     start: {
-      name: { [LocalizedString.EN_US]: 'Robot Begins In start' },
-      description: { [LocalizedString.EN_US]: 'Robot begins in starting box' },
+      name: tr('Robot Begins In start'),
+      description: tr('Robot begins in starting box'),
     },
     addItUp: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched a Circle ' },
-      description: { [LocalizedString.EN_US]: 'Robot touched a circle' },
+      name: tr('Robot Touched a Circle '),
+      description: tr('Robot touched a circle'),
     },
   },
   success: {
@@ -59,8 +57,8 @@ export default {
     rootId: 'completion',
   },
   successGoals: [
-    { exprId: 'startOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'addItUpOnce', name: { [LocalizedString.EN_US]: 'Touched Circles to add up to 20' } }
+    { exprId: 'startOnce', name: tr('Start in the Start Box') },
+    { exprId: 'addItUpOnce', name: tr('Touched Circles to add up to 20') }
   ],
   sceneId: 'jbc12',
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc14-Dance-Party.ts
+++ b/src/simulator/definitions/challenges/jbc14-Dance-Party.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 14' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 14: Dance Party`,
-  },
+  name: tr('JBC Challenge 14'),
+  description: tr(`Junior Botball Challenge 14: Dance Party`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,32 +19,32 @@ export default {
   defaultLanguage: 'c',
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: 'Robot not in Start Box' },
-      description: { [LocalizedString.EN_US]: 'Robot not in start box' },
+      name: tr('Robot not in Start Box'),
+      description: tr('Robot not in start box'),
     },
     leaveStartBox: {
-      name: { [LocalizedString.EN_US]: 'Robot Left Start' },
-      description: { [LocalizedString.EN_US]: 'Robot left starting box' },
+      name: tr('Robot Left Start'),
+      description: tr('Robot left starting box'),
     },
     clockwise360: {
-      name: { [LocalizedString.EN_US]: 'Robot 360 Clockwise' },
-      description: { [LocalizedString.EN_US]: 'Robot turned 360 degrees clockwise', },
+      name: tr('Robot 360 Clockwise'),
+      description: tr('Robot turned 360 degrees clockwise'),
     },
     counterClockwise360: {
-      name: { [LocalizedString.EN_US]: 'Robot 360 Counter Clockwise' },
-      description: { [LocalizedString.EN_US]: 'Robot turned 360 degrees counter clockwise', },
+      name: tr('Robot 360 Counter Clockwise'),
+      description: tr('Robot turned 360 degrees counter clockwise'),
     },
     driveForward: {
-      name: { [LocalizedString.EN_US]: 'Robot Drove Forward' },
-      description: { [LocalizedString.EN_US]: 'Robot drove forward', },
+      name: tr('Robot Drove Forward'),
+      description: tr('Robot drove forward'),
     },
     driveBackward: {
-      name: { [LocalizedString.EN_US]: 'Robot Drove Backward' },
-      description: { [LocalizedString.EN_US]: 'Robot drove backward', },
+      name: tr('Robot Drove Backward'),
+      description: tr('Robot drove backward'),
     },
     waveServo: {
-      name: { [LocalizedString.EN_US]: 'Robot Wave Servo' },
-      description: { [LocalizedString.EN_US]: 'Robot waved servo up and down at least once', },
+      name: tr('Robot Wave Servo'),
+      description: tr('Robot waved servo up and down at least once'),
     },
   },
   success: {
@@ -136,13 +134,13 @@ export default {
     rootId: 'completion',
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'leaveStartBoxOnce', name: { [LocalizedString.EN_US]: 'Leave the Start Box' } },
-    { exprId: 'clockwise360Once', name: { [LocalizedString.EN_US]: 'Turn 360° clockwise' } },
-    { exprId: 'counterClockwise360Once', name: { [LocalizedString.EN_US]: 'Turn 360° counter clockwise' } },
-    { exprId: 'driveForwardOnce', name: { [LocalizedString.EN_US]: 'Drive forward' } },
-    { exprId: 'driveBackwardOnce', name: { [LocalizedString.EN_US]: 'Drive backward' } },
-    { exprId: 'waveServoOnce', name: { [LocalizedString.EN_US]: 'Wave the servo' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'leaveStartBoxOnce', name: tr('Leave the Start Box') },
+    { exprId: 'clockwise360Once', name: tr('Turn 360° clockwise') },
+    { exprId: 'counterClockwise360Once', name: tr('Turn 360° counter clockwise') },
+    { exprId: 'driveForwardOnce', name: tr('Drive forward') },
+    { exprId: 'driveBackwardOnce', name: tr('Drive backward') },
+    { exprId: 'waveServoOnce', name: tr('Wave the servo') },
   ],
   sceneId: 'jbc14',
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc15-Go-Fetch.ts
+++ b/src/simulator/definitions/challenges/jbc15-Go-Fetch.ts
@@ -1,14 +1,12 @@
 import Author from "../../../db/Author";
 import Challenge from "../../../state/State/Challenge";
 import Expr from "../../../state/State/Challenge/Expr";
-import LocalizedString from "../../../util/LocalizedString";
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: "JBC Challenge 15" },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 15: Go Fetch`,
-  },
+  name: tr("JBC Challenge 15"),
+  description: tr(`Junior Botball Challenge 15: Go Fetch`),
   author: {
     type: Author.Type.Organization,
     id: "kipr",
@@ -21,16 +19,16 @@ export default {
   defaultLanguage: "c",
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot not in Start Box" },
-      description: { [LocalizedString.EN_US]: "Robot not in start box" },
+      name: tr("Robot not in Start Box"),
+      description: tr("Robot not in start box"),
     },
     canInStartBox: {
-      name: { [LocalizedString.EN_US]: "Can in Start Box" },
-      description: { [LocalizedString.EN_US]: "Can in start box" },
+      name: tr("Can in Start Box"),
+      description: tr("Can in start box"),
     },
     can11Upright: {
-      name: { [LocalizedString.EN_US]: "Can 11 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 11 upright" },
+      name: tr("Can 11 Upright"),
+      description: tr("Can 11 upright"),
     },
   },
   success: {
@@ -76,11 +74,11 @@ export default {
     rootId: "completion",
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'canInStartBox', name: { [LocalizedString.EN_US]: 'Bring can to Start Box' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'canInStartBox', name: tr('Bring can to Start Box') },
   ],
   failureGoals: [
-    { exprId: 'can11NotUpright', name: { [LocalizedString.EN_US]: 'Keep can 11 not upright' } },
+    { exprId: 'can11NotUpright', name: tr('Keep can 11 not upright') },
   ],
   sceneId: "jbc15",
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc16-Pick-Em-Up.ts
+++ b/src/simulator/definitions/challenges/jbc16-Pick-Em-Up.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 16' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 16: Pick 'Em Up`,
-  },
+  name: tr('JBC Challenge 16'),
+  description: tr(`Junior Botball Challenge 16: Pick 'Em Up`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,50 +19,50 @@ export default {
   defaultLanguage: 'c',
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: 'Robot not in Start Box' },
-      description: { [LocalizedString.EN_US]: 'Robot not in start box' },
+      name: tr('Robot not in Start Box'),
+      description: tr('Robot not in start box'),
     },
     can2PickedUp: {
-      name: { [LocalizedString.EN_US]: 'Can 2 Picked Up' },
-      description: { [LocalizedString.EN_US]: 'Can 2 picked up' },
+      name: tr('Can 2 Picked Up'),
+      description: tr('Can 2 picked up'),
     },
     can9PickedUp: {
-      name: { [LocalizedString.EN_US]: 'Can 9 Picked Up' },
-      description: { [LocalizedString.EN_US]: 'Can 9 picked up' },
+      name: tr('Can 9 Picked Up'),
+      description: tr('Can 9 picked up'),
     },
     can10PickedUp: {
-      name: { [LocalizedString.EN_US]: 'Can 10 Picked Up' },
-      description: { [LocalizedString.EN_US]: 'Can 10 picked up' },
+      name: tr('Can 10 Picked Up'),
+      description: tr('Can 10 picked up'),
     },
 
     can2Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 2 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 2 upright' },
+      name: tr('Can 2 Upright'),
+      description: tr('Can 2 upright'),
     },
     can9Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 9 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 9 upright' },
+      name: tr('Can 9 Upright'),
+      description: tr('Can 9 upright'),
     },
     can10Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 10 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 10 upright' },
+      name: tr('Can 10 Upright'),
+      description: tr('Can 10 upright'),
     },
 
     can2Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 2 Intersects Green Garage' },
-      description: { [LocalizedString.EN_US]: 'Can 2 intersects Green Garage' },
+      name: tr('Can 2 Intersects Green Garage'),
+      description: tr('Can 2 intersects Green Garage'),
     },
     can9Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 9 Intersects Blue Garage' },
-      description: { [LocalizedString.EN_US]: 'Can 9 intersects Blue Garage' },
+      name: tr('Can 9 Intersects Blue Garage'),
+      description: tr('Can 9 intersects Blue Garage'),
     },
     can9IntersectsPurple: {
-      name: { [LocalizedString.EN_US]: 'Can 9 Intersects Purple Garage' },
-      description: { [LocalizedString.EN_US]: 'Can 9 intersects Purple Garage' },
+      name: tr('Can 9 Intersects Purple Garage'),
+      description: tr('Can 9 intersects Purple Garage'),
     },
     can10Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 10 Intersects Yellow Garage' },
-      description: { [LocalizedString.EN_US]: 'Can 10 intersects Yellow Garage' },
+      name: tr('Can 10 Intersects Yellow Garage'),
+      description: tr('Can 10 intersects Yellow Garage'),
     },
 
   },
@@ -192,18 +190,18 @@ export default {
     rootId: 'completion',
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'can2Intersects', name: { [LocalizedString.EN_US]: 'Place can 2 in green garage' } },
-    { exprId: 'can9Intersects', name: { [LocalizedString.EN_US]: 'Place can 9 in blue garage' } },
-    { exprId: 'can10Intersects', name: { [LocalizedString.EN_US]: 'Place can 10 in yellow garage' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'can2Intersects', name: tr('Place can 2 in green garage') },
+    { exprId: 'can9Intersects', name: tr('Place can 9 in blue garage') },
+    { exprId: 'can10Intersects', name: tr('Place can 10 in yellow garage') },
   ],
   failureGoals: [
-    { exprId: 'can2NotUpright', name: { [LocalizedString.EN_US]: 'Can 2 not upright' } },
-    { exprId: 'can9NotUpright', name: { [LocalizedString.EN_US]: 'Can 9 not upright' } },
-    { exprId: 'can10NotUpright', name: { [LocalizedString.EN_US]: 'Can 10 not upright' } },
-    { exprId: 'can2NotPickedUpOnce', name: { [LocalizedString.EN_US]: 'Can 2 not picked up' } },
-    { exprId: 'can9NotPickedUpOnce', name: { [LocalizedString.EN_US]: 'Can 9 not picked up' } },
-    { exprId: 'can10NotPickedUpOnce', name: { [LocalizedString.EN_US]: 'Can 10 not picked up' } },
+    { exprId: 'can2NotUpright', name: tr('Can 2 not upright') },
+    { exprId: 'can9NotUpright', name: tr('Can 9 not upright') },
+    { exprId: 'can10NotUpright', name: tr('Can 10 not upright') },
+    { exprId: 'can2NotPickedUpOnce', name: tr('Can 2 not picked up') },
+    { exprId: 'can9NotPickedUpOnce', name: tr('Can 9 not picked up') },
+    { exprId: 'can10NotPickedUpOnce', name: tr('Can 10 not picked up') },
   ],
   sceneId: 'jbc16',
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc17-Mountain-Rescue.ts
+++ b/src/simulator/definitions/challenges/jbc17-Mountain-Rescue.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 17' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 17: Mountain Rescue`,
-  },
+  name: tr('JBC Challenge 17'),
+  description: tr(`Junior Botball Challenge 17: Mountain Rescue`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,32 +19,32 @@ export default {
   defaultLanguage: 'c',
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: 'Robot not in Start Box' },
-      description: { [LocalizedString.EN_US]: 'Robot not in start box' },
+      name: tr('Robot not in Start Box'),
+      description: tr('Robot not in start box'),
     },
     can1Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 1 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 1 is upright', },
+      name: tr('Can 1 Upright'),
+      description: tr('Can 1 is upright'),
     },
     can2Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 2 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 2 is upright', },
+      name: tr('Can 2 Upright'),
+      description: tr('Can 2 is upright'),
     },
     can3Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 3 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 3 is upright', },
+      name: tr('Can 3 Upright'),
+      description: tr('Can 3 is upright'),
     },
     can1Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 1 Intersects' },
-      description: { [LocalizedString.EN_US]: 'Can 1 rescued intersecting starting box', },
+      name: tr('Can 1 Intersects'),
+      description: tr('Can 1 rescued intersecting starting box'),
     },
     can2Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 2 Intersects' },
-      description: { [LocalizedString.EN_US]: 'Can 2 rescued intersecting starting box', },
+      name: tr('Can 2 Intersects'),
+      description: tr('Can 2 rescued intersecting starting box'),
     },
     can3Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 3 Intersects' },
-      description: { [LocalizedString.EN_US]: 'Can 3 rescued intersecting starting box', },
+      name: tr('Can 3 Intersects'),
+      description: tr('Can 3 rescued intersecting starting box'),
     },
   },
   success: {
@@ -139,15 +137,15 @@ export default {
     rootId: 'completion',
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'can1Intersects', name: { [LocalizedString.EN_US]: 'Rescue can 1 to start box' } },
-    { exprId: 'can2Intersects', name: { [LocalizedString.EN_US]: 'Rescue can 2 to start box' } },
-    { exprId: 'can3Intersects', name: { [LocalizedString.EN_US]: 'Rescue can 3 to start box' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'can1Intersects', name: tr('Rescue can 1 to start box') },
+    { exprId: 'can2Intersects', name: tr('Rescue can 2 to start box') },
+    { exprId: 'can3Intersects', name: tr('Rescue can 3 to start box') },
   ],
   failureGoals: [
-    { exprId: 'can1NotUpright', name: { [LocalizedString.EN_US]: 'Can 1 not upright' } },
-    { exprId: 'can2NotUpright', name: { [LocalizedString.EN_US]: 'Can 2 not upright' } },
-    { exprId: 'can3NotUpright', name: { [LocalizedString.EN_US]: 'Can 3 not upright' } },
+    { exprId: 'can1NotUpright', name: tr('Can 1 not upright') },
+    { exprId: 'can2NotUpright', name: tr('Can 2 not upright') },
+    { exprId: 'can3NotUpright', name: tr('Can 3 not upright') },
   ],
   sceneId: 'jbc17',
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc18-Stackerz-New.ts
+++ b/src/simulator/definitions/challenges/jbc18-Stackerz-New.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 18' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 18: Stackerz`,
-  },
+  name: tr('JBC Challenge 18'),
+  description: tr(`Junior Botball Challenge 18: Stackerz`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -23,18 +21,18 @@ export default {
 
 
     leaveStartBox: {
-      name: { [LocalizedString.EN_US]: 'Robot Left Start' },
-      description: { [LocalizedString.EN_US]: 'Robot left starting box' },
+      name: tr('Robot Left Start'),
+      description: tr('Robot left starting box'),
     },
 
     canStacked: {
-      name: { [LocalizedString.EN_US]: 'One Can Stacked' },
-      description: { [LocalizedString.EN_US]: 'One can is stacked on another' },
+      name: tr('One Can Stacked'),
+      description: tr('One can is stacked on another'),
     },
 
     robotTouchCan: {
-      name: { [LocalizedString.EN_US]: 'Robot Touching Can' },
-      description: { [LocalizedString.EN_US]: 'Robot is touching a can' },
+      name: tr('Robot Touching Can'),
+      description: tr('Robot is touching a can'),
     },
 
   },
@@ -75,11 +73,11 @@ export default {
     rootId: 'completion',
   },
   successGoals: [
-    { exprId: 'leaveStartBoxOnce', name: { [LocalizedString.EN_US]: 'Leave the Start Box' } },
-    { exprId: 'canStacked', name: { [LocalizedString.EN_US]: 'Stack one can on another' } },
+    { exprId: 'leaveStartBoxOnce', name: tr('Leave the Start Box') },
+    { exprId: 'canStacked', name: tr('Stack one can on another') },
   ],
   failureGoals: [
-    { exprId: 'robotTouchCan', name: { [LocalizedString.EN_US]: 'Robot touching can' } },
+    { exprId: 'robotTouchCan', name: tr('Robot touching can') },
   ],
   sceneId: 'jbc18',
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc19-Bump.ts
+++ b/src/simulator/definitions/challenges/jbc19-Bump.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 19' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 19: Bump`,
-  },
+  name: tr('JBC Challenge 19'),
+  description: tr(`Junior Botball Challenge 19: Bump`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,15 +19,12 @@ export default {
   defaultLanguage: 'c',
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot not in Start Box" },
-      description: { [LocalizedString.EN_US]: "Robot not in start box" },
+      name: tr("Robot not in Start Box"),
+      description: tr("Robot not in start box"),
     },
     driveForwardTouch: {
-      name: { [LocalizedString.EN_US]: 'Robot Forward Touch' },
-      description: {
-        [LocalizedString.EN_US]:
-          'Robot drove forward and touched ream of paper',
-      },
+      name: tr('Robot Forward Touch'),
+      description: tr('Robot drove forward and touched ream of paper'),
     },
   },
   success: {
@@ -65,8 +60,8 @@ export default {
     rootId: 'completion',
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'driveForwardTouch', name: { [LocalizedString.EN_US]: 'Drive forward and touch the ream' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'driveForwardTouch', name: tr('Drive forward and touch the ream') },
   ],
   sceneId: 'jbc19',
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc2-Ring-Around-the-Can.ts
+++ b/src/simulator/definitions/challenges/jbc2-Ring-Around-the-Can.ts
@@ -1,14 +1,12 @@
 import Author from "../../../db/Author";
 import Challenge from "../../../state/State/Challenge";
 import Expr from "../../../state/State/Challenge/Expr";
-import LocalizedString from "../../../util/LocalizedString";
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: "JBC Challenge 2" },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 2: Ring Around the Can`,
-  },
+  name: tr("JBC Challenge 2"),
+  description: tr(`Junior Botball Challenge 2: Ring Around the Can`),
   author: {
     type: Author.Type.Organization,
     id: "kipr",
@@ -21,38 +19,32 @@ export default {
   defaultLanguage: "c",
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot not in Start Box" },
-      description: { [LocalizedString.EN_US]: "Robot not in start box" },
+      name: tr("Robot not in Start Box"),
+      description: tr("Robot not in start box"),
     },
     can6Intersects: {
-      name: { [LocalizedString.EN_US]: "Can 6 Intersects" },
-      description: { [LocalizedString.EN_US]: "Can 6 intersects circle 6" },
+      name: tr("Can 6 Intersects"),
+      description: tr("Can 6 intersects circle 6"),
     },
     can6Upright: {
-      name: { [LocalizedString.EN_US]: "Can 6 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 6 upright on circle 6" },
+      name: tr("Can 6 Upright"),
+      description: tr("Can 6 upright on circle 6"),
     },
     returnStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot Rentered Start" },
-      description: { [LocalizedString.EN_US]: "Robot reentered starting box" },
+      name: tr("Robot Rentered Start"),
+      description: tr("Robot reentered starting box"),
     },
     rightSide: {
-      name: { [LocalizedString.EN_US]: "Robot Passed Right Side" },
-      description: {
-        [LocalizedString.EN_US]: "Robot passed right side of can 6",
-      },
+      name: tr("Robot Passed Right Side"),
+      description: tr("Robot passed right side of can 6"),
     },
     topSide: {
-      name: { [LocalizedString.EN_US]: "Robot Passed Top Side" },
-      description: {
-        [LocalizedString.EN_US]: "Robot passed top side of can 6",
-      },
+      name: tr("Robot Passed Top Side"),
+      description: tr("Robot passed top side of can 6"),
     },
     leftSide: {
-      name: { [LocalizedString.EN_US]: "Robot Passed left Side" },
-      description: {
-        [LocalizedString.EN_US]: "Robot passed left side of can 6",
-      },
+      name: tr("Robot Passed left Side"),
+      description: tr("Robot passed left side of can 6"),
     },
   },
   success: {
@@ -149,33 +141,33 @@ export default {
   successGoals: [
     {
       exprId: 'inStartBoxOnce',
-      name: { [LocalizedString.EN_US]: 'Start in the Start Box' },
+      name: tr('Start in the Start Box'),
     },
     {
       exprId: 'rightSideOnce',
-      name: { [LocalizedString.EN_US]: 'Pass the right side of can 6' },
+      name: tr('Pass the right side of can 6'),
     },
     {
       exprId: 'topSideOnce',
-      name: { [LocalizedString.EN_US]: 'Pass the top side of can 6' },
+      name: tr('Pass the top side of can 6'),
     },
     {
       exprId: 'leftSideOnce',
-      name: { [LocalizedString.EN_US]: 'Pass the left side of can 6' },
+      name: tr('Pass the left side of can 6'),
     },
     {
       exprId: 'returnStartBox',
-      name: { [LocalizedString.EN_US]: 'Return to the Start Box' },
+      name: tr('Return to the Start Box'),
     },
   ],
   failureGoals: [
     {
       exprId: 'can6NotIntersects',
-      name: { [LocalizedString.EN_US]: 'Can 6 not in circle 6' },
+      name: tr('Can 6 not in circle 6'),
     },
     {
       exprId: 'can6NotUpright',
-      name: { [LocalizedString.EN_US]: 'Can 6 not upright' },
+      name: tr('Can 6 not upright'),
     },
   ],
   sceneId: "jbc2",

--- a/src/simulator/definitions/challenges/jbc20-Amazing.ts
+++ b/src/simulator/definitions/challenges/jbc20-Amazing.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 20' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 20: A'mazing`,
-  },
+  name: tr('JBC Challenge 20'),
+  description: tr(`Junior Botball Challenge 20: A'mazing`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,24 +19,24 @@ export default {
   defaultLanguage: 'c',
   events: {
     inStartBox: {
-      name: { [LocalizedString.EN_US]: "In Start Box" },
-      description: { [LocalizedString.EN_US]: "Robot in start box" },
+      name: tr("In Start Box"),
+      description: tr("Robot in start box"),
     },
     ream1Touched: {
-      name: { [LocalizedString.EN_US]: "Ream 1 Touched" },
-      description: { [LocalizedString.EN_US]: "Robot touched ream 1" },
+      name: tr("Ream 1 Touched"),
+      description: tr("Robot touched ream 1"),
     },
     ream2Touched: {
-      name: { [LocalizedString.EN_US]: "Ream 2 Touched" },
-      description: { [LocalizedString.EN_US]: "Robot touched ream 2" },
+      name: tr("Ream 2 Touched"),
+      description: tr("Robot touched ream 2"),
     },
     ream3Touched: {
-      name: { [LocalizedString.EN_US]: "Ream 3 Touched" },
-      description: { [LocalizedString.EN_US]: "Robot touched ream 3" },
+      name: tr("Ream 3 Touched"),
+      description: tr("Robot touched ream 3"),
     },
     ream4Touched: {
-      name: { [LocalizedString.EN_US]: "Ream 4 Touched" },
-      description: { [LocalizedString.EN_US]: "Robot touched ream 4" },
+      name: tr("Ream 4 Touched"),
+      description: tr("Robot touched ream 4"),
     },
   },
   success: {
@@ -98,11 +96,11 @@ export default {
     rootId: 'completion',
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'ream1TouchedOnce', name: { [LocalizedString.EN_US]: 'Touch ream 1' } },
-    { exprId: 'ream2TouchedOnce', name: { [LocalizedString.EN_US]: 'Touch ream 2' } },
-    { exprId: 'ream3TouchedOnce', name: { [LocalizedString.EN_US]: 'Touch ream 3' } },
-    { exprId: 'ream4TouchedOnce', name: { [LocalizedString.EN_US]: 'Touch ream 4' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'ream1TouchedOnce', name: tr('Touch ream 1') },
+    { exprId: 'ream2TouchedOnce', name: tr('Touch ream 2') },
+    { exprId: 'ream3TouchedOnce', name: tr('Touch ream 3') },
+    { exprId: 'ream4TouchedOnce', name: tr('Touch ream 4') },
   ],
   sceneId: 'jbc20',
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc21-Proximity.ts
+++ b/src/simulator/definitions/challenges/jbc21-Proximity.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 21' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 21: Proximity`,
-  },
+  name: tr('JBC Challenge 21'),
+  description: tr(`Junior Botball Challenge 21: Proximity`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,16 +19,16 @@ export default {
   defaultLanguage: 'c',
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot not in Start Box" },
-      description: { [LocalizedString.EN_US]: "Robot not in start box" },
+      name: tr("Robot not in Start Box"),
+      description: tr("Robot not in start box"),
     },
     stopAtReam: {
-      name: { [LocalizedString.EN_US]: "Stop at Ream" },
-      description: { [LocalizedString.EN_US]: "Robot stops at ream" },
+      name: tr("Stop at Ream"),
+      description: tr("Robot stops at ream"),
     },
     touchedReam: {
-      name: { [LocalizedString.EN_US]: "Bump Ream" },
-      description: { [LocalizedString.EN_US]: "Robot bumps ream" },
+      name: tr("Bump Ream"),
+      description: tr("Robot bumps ream"),
     },
   },
   success: {
@@ -87,11 +85,11 @@ export default {
     rootId: 'failure',
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'stopAtReam', name: { [LocalizedString.EN_US]: 'Stop at the ream' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'stopAtReam', name: tr('Stop at the ream') },
   ],
   failureGoals: [
-    { exprId: 'touchedReamOnce', name: { [LocalizedString.EN_US]: 'Do not bump the ream' } },
+    { exprId: 'touchedReamOnce', name: tr('Do not bump the ream') },
   ],
   sceneId: 'jbc21',
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc22-Search-and-Rescue.ts
+++ b/src/simulator/definitions/challenges/jbc22-Search-and-Rescue.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 22' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 22: Search and Rescue`,
-  },
+  name: tr('JBC Challenge 22'),
+  description: tr(`Junior Botball Challenge 22: Search and Rescue`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,16 +19,16 @@ export default {
   defaultLanguage: 'c',
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot not in Start Box" },
-      description: { [LocalizedString.EN_US]: "Robot not in start box" },
+      name: tr("Robot not in Start Box"),
+      description: tr("Robot not in start box"),
     },
     canInStartBox: {
-      name: { [LocalizedString.EN_US]: "Can in Start Box" },
-      description: { [LocalizedString.EN_US]: "Can in start box" },
+      name: tr("Can in Start Box"),
+      description: tr("Can in start box"),
     },
     canUpright: {
-      name: { [LocalizedString.EN_US]: "Can Upright" },
-      description: { [LocalizedString.EN_US]: "Can is upright" },
+      name: tr("Can Upright"),
+      description: tr("Can is upright"),
     },
   },
   success: {
@@ -75,11 +73,11 @@ export default {
     rootId: 'completion',
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'canInStartBox', name: { [LocalizedString.EN_US]: 'Bring can to Start Box' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'canInStartBox', name: tr('Bring can to Start Box') },
   ],
   failureGoals: [
-    { exprId: 'canNotUpright', name: { [LocalizedString.EN_US]: 'Can not upright' } },
+    { exprId: 'canNotUpright', name: tr('Can not upright') },
   ],
   sceneId: 'jbc22',
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc23-Find-the-Black-Line.ts
+++ b/src/simulator/definitions/challenges/jbc23-Find-the-Black-Line.ts
@@ -1,15 +1,13 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
 import { on } from 'form-data';
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 23' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 23: Find the Black Line`,
-  },
+  name: tr('JBC Challenge 23'),
+  description: tr(`Junior Botball Challenge 23: Find the Black Line`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -22,12 +20,12 @@ export default {
   defaultLanguage: 'c',
   events: {
     stopAtBlackLine: {
-      name: { [LocalizedString.EN_US]: "Robot Stops at Black Line" },
-      description: { [LocalizedString.EN_US]: "Robot stops at black line" },
+      name: tr("Robot Stops at Black Line"),
+      description: tr("Robot stops at black line"),
     },
     onCircle: {
-      name: { [LocalizedString.EN_US]: "Robot Over Circle" },
-      description: { [LocalizedString.EN_US]: "Robot over selected circle" },
+      name: tr("Robot Over Circle"),
+      description: tr("Robot over selected circle"),
     },
   },
   success: {
@@ -56,8 +54,8 @@ export default {
     rootId: 'completion',
   },
   successGoals: [
-    { exprId: 'onCircleOnce', name: { [LocalizedString.EN_US]: 'Started over the circle' } },
-    { exprId: 'stopAtBlackLine', name: { [LocalizedString.EN_US]: 'Stop at the black line' } },
+    { exprId: 'onCircleOnce', name: tr('Started over the circle') },
+    { exprId: 'stopAtBlackLine', name: tr('Stop at the black line') },
   ],
   sceneId: 'jbc23',
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc24-Walk-the-Line.ts
+++ b/src/simulator/definitions/challenges/jbc24-Walk-the-Line.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 24' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 24: Walk the Line`,
-  },
+  name: tr('JBC Challenge 24'),
+  description: tr(`Junior Botball Challenge 24: Walk the Line`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,11 +19,8 @@ export default {
   defaultLanguage: 'c',
   events: {
     lineFollow: {
-      name: { [LocalizedString.EN_US]: 'Robot Walks the Line' },
-      description: {
-        [LocalizedString.EN_US]:
-          'Robot uses reflectance sensor to follow the black line until Finish Line ',
-      },
+      name: tr('Robot Walks the Line'),
+      description: tr('Robot uses reflectance sensor to follow the black line until Finish Line '),
     },
   },
   success: {
@@ -47,7 +42,7 @@ export default {
     rootId: 'completion',
   },
   successGoals: [
-    { exprId: 'lineFollow', name: { [LocalizedString.EN_US]: 'Line follow to the finish line' } },
+    { exprId: 'lineFollow', name: tr('Line follow to the finish line') },
   ],
   sceneId: 'jbc24',
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc3-Precision-Parking.ts
+++ b/src/simulator/definitions/challenges/jbc3-Precision-Parking.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 3' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 3: Precision Parking`,
-  },
+  name: tr('JBC Challenge 3'),
+  description: tr(`Junior Botball Challenge 3: Precision Parking`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,30 +19,24 @@ export default {
   defaultLanguage: 'c',
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: 'Robot not in Start Box' },
-      description: { [LocalizedString.EN_US]: 'Robot not in start box' },
+      name: tr('Robot not in Start Box'),
+      description: tr('Robot not in start box'),
     },
     touchGarageLines: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched Garage Lines' },
-      description: {
-        [LocalizedString.EN_US]: 'Robot touched garage boundaries',
-      },
+      name: tr('Robot Touched Garage Lines'),
+      description: tr('Robot touched garage boundaries'),
     },
     singleGarageRun1: {
-      name: { [LocalizedString.EN_US]: 'Robot Parked in One Garage' },
-      description: {
-        [LocalizedString.EN_US]: 'Robot parked in only one garage',
-      },
+      name: tr('Robot Parked in One Garage'),
+      description: tr('Robot parked in only one garage'),
     },
     singleGarageRun2: {
-      name: { [LocalizedString.EN_US]: 'Robot Parked in Different Garage' },
-      description: {
-        [LocalizedString.EN_US]: 'Robot parked in a different garage',
-      },
+      name: tr('Robot Parked in Different Garage'),
+      description: tr('Robot parked in a different garage'),
     },
     returnStartBox: {
-      name: { [LocalizedString.EN_US]: 'Robot Returned Start' },
-      description: { [LocalizedString.EN_US]: 'Robot returned to starting box' },
+      name: tr('Robot Returned Start'),
+      description: tr('Robot returned to starting box'),
     },
   },
   success: {
@@ -114,25 +106,25 @@ export default {
   successGoals: [
     {
       exprId: 'inStartBoxOnce',
-      name: { [LocalizedString.EN_US]: 'Start in the Start Box' },
+      name: tr('Start in the Start Box'),
     },
     {
       exprId: 'singleGarageRun1Once',
-      name: { [LocalizedString.EN_US]: 'Park in one garage' },
+      name: tr('Park in one garage'),
     },
     {
       exprId: 'singleGarageRun2Once',
-      name: { [LocalizedString.EN_US]: 'Park in a different garage' },
+      name: tr('Park in a different garage'),
     },
     {
       exprId: 'returnStartBoxOnce',
-      name: { [LocalizedString.EN_US]: 'Return to the Start Box' },
+      name: tr('Return to the Start Box'),
     },
   ],
   failureGoals: [
     {
       exprId: 'touchGarageLines',
-      name: { [LocalizedString.EN_US]: 'Do not touch garage boundaries' },
+      name: tr('Do not touch garage boundaries'),
     },
   ],
   sceneId: 'jbc3',

--- a/src/simulator/definitions/challenges/jbc4-Serpentine.ts
+++ b/src/simulator/definitions/challenges/jbc4-Serpentine.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 4' },
-  description: {
-    [LocalizedString.EN_US]: 'Junior Botball Challenge 4: Serpentine',
-  },
+  name: tr('JBC Challenge 4'),
+  description: tr('Junior Botball Challenge 4: Serpentine'),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,44 +19,44 @@ export default {
   defaultLanguage: 'c',
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: 'Robot not in Start Box' },
-      description: { [LocalizedString.EN_US]: 'Robot not in start box' },
+      name: tr('Robot not in Start Box'),
+      description: tr('Robot not in start box'),
     },
     wrongOrder: {
-      name: { [LocalizedString.EN_US]: 'Circle Touched Out of Order' },
-      description: { [LocalizedString.EN_US]: 'Circle was touched out of order' },
+      name: tr('Circle Touched Out of Order'),
+      description: tr('Circle was touched out of order'),
     },
     touched1: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched Circle 1' },
-      description: { [LocalizedString.EN_US]: 'Robot touched circle 1' },
+      name: tr('Robot Touched Circle 1'),
+      description: tr('Robot touched circle 1'),
     },
     touched2: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched Circle 2' },
-      description: { [LocalizedString.EN_US]: 'Robot touched circle 2' },
+      name: tr('Robot Touched Circle 2'),
+      description: tr('Robot touched circle 2'),
     },
     touched3: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched Circle 3' },
-      description: { [LocalizedString.EN_US]: 'Robot touched circle 3' },
+      name: tr('Robot Touched Circle 3'),
+      description: tr('Robot touched circle 3'),
     },
     touched4: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched Circle 4' },
-      description: { [LocalizedString.EN_US]: 'Robot touched circle 4' },
+      name: tr('Robot Touched Circle 4'),
+      description: tr('Robot touched circle 4'),
     },
     touched5: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched Circle 5' },
-      description: { [LocalizedString.EN_US]: 'Robot touched circle 5' },
+      name: tr('Robot Touched Circle 5'),
+      description: tr('Robot touched circle 5'),
     },
     touched6: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched Circle 6' },
-      description: { [LocalizedString.EN_US]: 'Robot touched circle 6' },
+      name: tr('Robot Touched Circle 6'),
+      description: tr('Robot touched circle 6'),
     },
     touched7: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched Circle 7' },
-      description: { [LocalizedString.EN_US]: 'Robot touched circle 7' },
+      name: tr('Robot Touched Circle 7'),
+      description: tr('Robot touched circle 7'),
     },
     touched8: {
-      name: { [LocalizedString.EN_US]: 'Robot Touched Circle 8' },
-      description: { [LocalizedString.EN_US]: 'Robot touched circle 8' },
+      name: tr('Robot Touched Circle 8'),
+      description: tr('Robot touched circle 8'),
     },
   },
   success: {
@@ -179,21 +177,21 @@ export default {
   successGoals: [
     {
       exprId: 'inStartBoxOnce',
-      name: { [LocalizedString.EN_US]: 'Start in the Start Box' },
+      name: tr('Start in the Start Box'),
     },
-    { exprId: 'touched1Once', name: { [LocalizedString.EN_US]: 'Touch circle 1' } },
-    { exprId: 'touched2Once', name: { [LocalizedString.EN_US]: 'Touch circle 2' } },
-    { exprId: 'touched3Once', name: { [LocalizedString.EN_US]: 'Touch circle 3' } },
-    { exprId: 'touched4Once', name: { [LocalizedString.EN_US]: 'Touch circle 4' } },
-    { exprId: 'touched5Once', name: { [LocalizedString.EN_US]: 'Touch circle 5' } },
-    { exprId: 'touched6Once', name: { [LocalizedString.EN_US]: 'Touch circle 6' } },
-    { exprId: 'touched7Once', name: { [LocalizedString.EN_US]: 'Touch circle 7' } },
-    { exprId: 'touched8Once', name: { [LocalizedString.EN_US]: 'Touch circle 8' } },
+    { exprId: 'touched1Once', name: tr('Touch circle 1') },
+    { exprId: 'touched2Once', name: tr('Touch circle 2') },
+    { exprId: 'touched3Once', name: tr('Touch circle 3') },
+    { exprId: 'touched4Once', name: tr('Touch circle 4') },
+    { exprId: 'touched5Once', name: tr('Touch circle 5') },
+    { exprId: 'touched6Once', name: tr('Touch circle 6') },
+    { exprId: 'touched7Once', name: tr('Touch circle 7') },
+    { exprId: 'touched8Once', name: tr('Touch circle 8') },
   ],
   failureGoals: [
     {
       exprId: 'wrongOrderOnce',
-      name: { [LocalizedString.EN_US]: 'Circle touched out of order' },
+      name: tr('Circle touched out of order'),
     },
   ],
   sceneId: 'jbc4',

--- a/src/simulator/definitions/challenges/jbc5-Odd-Numbers.ts
+++ b/src/simulator/definitions/challenges/jbc5-Odd-Numbers.ts
@@ -1,14 +1,12 @@
 import Author from "../../../db/Author";
 import Challenge from "../../../state/State/Challenge";
 import Expr from "../../../state/State/Challenge/Expr";
-import LocalizedString from "../../../util/LocalizedString";
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: "JBC Challenge 5" },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 5: Odd Numbers`,
-  },
+  name: tr("JBC Challenge 5"),
+  description: tr(`Junior Botball Challenge 5: Odd Numbers`),
   author: {
     type: Author.Type.Organization,
     id: "kipr",
@@ -21,40 +19,40 @@ export default {
   defaultLanguage: "c",
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot not in Start Box" },
-      description: { [LocalizedString.EN_US]: "Robot not in start box" },
+      name: tr("Robot not in Start Box"),
+      description: tr("Robot not in start box"),
     },
     touchedEvenCircle: {
-      name: { [LocalizedString.EN_US]: "Even Circle Touched" },
-      description: { [LocalizedString.EN_US]: "Even circle touched" },
+      name: tr("Even Circle Touched"),
+      description: tr("Even circle touched"),
     },
     wrongOrder: {
-      name: { [LocalizedString.EN_US]: "Circle Touched Out of Order" },
-      description: { [LocalizedString.EN_US]: "Circle was touched out of order" },
+      name: tr("Circle Touched Out of Order"),
+      description: tr("Circle was touched out of order"),
     },
     circle1Touched: {
-      name: { [LocalizedString.EN_US]: "Circle 1 Touched" },
-      description: { [LocalizedString.EN_US]: "Circle 1 was touched" },
+      name: tr("Circle 1 Touched"),
+      description: tr("Circle 1 was touched"),
     },
     circle3Touched: {
-      name: { [LocalizedString.EN_US]: "Circle 3 Touched" },
-      description: { [LocalizedString.EN_US]: "Circle 3 was touched" },
+      name: tr("Circle 3 Touched"),
+      description: tr("Circle 3 was touched"),
     },
     circle5Touched: {
-      name: { [LocalizedString.EN_US]: "Circle 5 Touched" },
-      description: { [LocalizedString.EN_US]: "Circle 5 was touched" },
+      name: tr("Circle 5 Touched"),
+      description: tr("Circle 5 was touched"),
     },
     circle7Touched: {
-      name: { [LocalizedString.EN_US]: "Circle 7 Touched" },
-      description: { [LocalizedString.EN_US]: "Circle 7 was touched" },
+      name: tr("Circle 7 Touched"),
+      description: tr("Circle 7 was touched"),
     },
     circle9Touched: {
-      name: { [LocalizedString.EN_US]: "Circle 9 Touched" },
-      description: { [LocalizedString.EN_US]: "Circle 9 was touched" },
+      name: tr("Circle 9 Touched"),
+      description: tr("Circle 9 was touched"),
     },
     circle11Touched: {
-      name: { [LocalizedString.EN_US]: "Circle 11 Touched" },
-      description: { [LocalizedString.EN_US]: "Circle 11 was touched" },
+      name: tr("Circle 11 Touched"),
+      description: tr("Circle 11 was touched"),
     },
   },
   success: {
@@ -170,22 +168,22 @@ export default {
     rootId: "failure"
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'circle1TouchedOnce', name: { [LocalizedString.EN_US]: 'Touch circle 1' } },
-    { exprId: 'circle3TouchedOnce', name: { [LocalizedString.EN_US]: 'Touch circle 3' } },
-    { exprId: 'circle5TouchedOnce', name: { [LocalizedString.EN_US]: 'Touch circle 5' } },
-    { exprId: 'circle7TouchedOnce', name: { [LocalizedString.EN_US]: 'Touch circle 7' } },
-    { exprId: 'circle9TouchedOnce', name: { [LocalizedString.EN_US]: 'Touch circle 9' } },
-    { exprId: 'circle11TouchedOnce', name: { [LocalizedString.EN_US]: 'Touch circle 11' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'circle1TouchedOnce', name: tr('Touch circle 1') },
+    { exprId: 'circle3TouchedOnce', name: tr('Touch circle 3') },
+    { exprId: 'circle5TouchedOnce', name: tr('Touch circle 5') },
+    { exprId: 'circle7TouchedOnce', name: tr('Touch circle 7') },
+    { exprId: 'circle9TouchedOnce', name: tr('Touch circle 9') },
+    { exprId: 'circle11TouchedOnce', name: tr('Touch circle 11') },
   ],
   failureGoals: [
     {
       exprId: 'touchedEvenCircleOnce',
-      name: { [LocalizedString.EN_US]: 'Touched an even circle' },
+      name: tr('Touched an even circle'),
     },
     {
       exprId: 'wrongOrderOnce',
-      name: { [LocalizedString.EN_US]: 'Circle touched out of order' },
+      name: tr('Circle touched out of order'),
     },
   ],
   sceneId: "jbc5",

--- a/src/simulator/definitions/challenges/jbc6-Figure-Eight.ts
+++ b/src/simulator/definitions/challenges/jbc6-Figure-Eight.ts
@@ -1,14 +1,12 @@
 import Author from "../../../db/Author";
 import Challenge from "../../../state/State/Challenge";
 import Expr from "../../../state/State/Challenge/Expr";
-import LocalizedString from "../../../util/LocalizedString";
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: "JBC Challenge 6" },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 6: Figure Eight`,
-  },
+  name: tr("JBC Challenge 6"),
+  description: tr(`Junior Botball Challenge 6: Figure Eight`),
   author: {
     type: Author.Type.Organization,
     id: "kipr",
@@ -21,37 +19,35 @@ export default {
   defaultLanguage: "c",
   events: {
     can4Intersects: {
-      name: { [LocalizedString.EN_US]: "Can 4 Intersects" },
-      description: { [LocalizedString.EN_US]: "Can 4 intersects circle 4" },
+      name: tr("Can 4 Intersects"),
+      description: tr("Can 4 intersects circle 4"),
     },
     can9Intersects: {
-      name: { [LocalizedString.EN_US]: "Can 9 Intersects" },
-      description: { [LocalizedString.EN_US]: "Can 9 intersects circle 9" },
+      name: tr("Can 9 Intersects"),
+      description: tr("Can 9 intersects circle 9"),
     },
 
     can4Upright: {
-      name: { [LocalizedString.EN_US]: "Can 4 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 4 upright on circle 4" },
+      name: tr("Can 4 Upright"),
+      description: tr("Can 4 upright on circle 4"),
     },
     can9Upright: {
-      name: { [LocalizedString.EN_US]: "Can 9 Upright" },
-      description: { [LocalizedString.EN_US]: "Can 9 upright on circle 9" },
+      name: tr("Can 9 Upright"),
+      description: tr("Can 9 upright on circle 9"),
     },
 
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot not in Start Box" },
-      description: { [LocalizedString.EN_US]: "Robot not in start box" },
+      name: tr("Robot not in Start Box"),
+      description: tr("Robot not in start box"),
     },
     returnStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot Rentered Start" },
-      description: { [LocalizedString.EN_US]: "Robot reentered starting box" },
+      name: tr("Robot Rentered Start"),
+      description: tr("Robot reentered starting box"),
     },
 
     figureEight: {
-      name: { [LocalizedString.EN_US]: "Robot Figure Eight" },
-      description: {
-        [LocalizedString.EN_US]: "Robot did a figure eight around cans 4 and 9",
-      },
+      name: tr("Robot Figure Eight"),
+      description: tr("Robot did a figure eight around cans 4 and 9"),
     },
   },
   success: {
@@ -143,15 +139,15 @@ export default {
     rootId: "completion",
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'figureEightOnce', name: { [LocalizedString.EN_US]: 'Complete a figure eight' } },
-    { exprId: 'returnStartBoxOnce', name: { [LocalizedString.EN_US]: 'Return to the Start Box' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'figureEightOnce', name: tr('Complete a figure eight') },
+    { exprId: 'returnStartBoxOnce', name: tr('Return to the Start Box') },
   ],
   failureGoals: [
-    { exprId: 'can4NotUpright', name: { [LocalizedString.EN_US]: 'Can 4 not upright in circle 4' } },
-    { exprId: 'can9NotUpright', name: { [LocalizedString.EN_US]: 'Can 9 not upright in circle 9' } },
-    { exprId: 'can4NotIntersects', name: { [LocalizedString.EN_US]: 'Can 4 does not intersect circle 4' } },
-    { exprId: 'can9NotIntersects', name: { [LocalizedString.EN_US]: 'Can 9 does not intersect circle 9' } },
+    { exprId: 'can4NotUpright', name: tr('Can 4 not upright in circle 4') },
+    { exprId: 'can9NotUpright', name: tr('Can 9 not upright in circle 9') },
+    { exprId: 'can4NotIntersects', name: tr('Can 4 does not intersect circle 4') },
+    { exprId: 'can9NotIntersects', name: tr('Can 9 does not intersect circle 9') },
   ],
   sceneId: "jbc6",
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc7-Load-Em-Up.ts
+++ b/src/simulator/definitions/challenges/jbc7-Load-Em-Up.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 7' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 7: Load 'Em Up`,
-  },
+  name: tr('JBC Challenge 7'),
+  description: tr(`Junior Botball Challenge 7: Load 'Em Up`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,37 +19,37 @@ export default {
   defaultLanguage: 'c',
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: 'Robot not in Start Box' },
-      description: { [LocalizedString.EN_US]: 'Robot not in start box' },
+      name: tr('Robot not in Start Box'),
+      description: tr('Robot not in start box'),
     },
     can2Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 2 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 2 upright' },
+      name: tr('Can 2 Upright'),
+      description: tr('Can 2 upright'),
     },
     can9Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 9 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 9 upright' },
+      name: tr('Can 9 Upright'),
+      description: tr('Can 9 upright'),
     },
     can10Upright: {
-      name: { [LocalizedString.EN_US]: 'Can 10 Upright' },
-      description: { [LocalizedString.EN_US]: 'Can 10 upright' },
+      name: tr('Can 10 Upright'),
+      description: tr('Can 10 upright'),
     },
 
     can2Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 2 Intersects Green Garage' },
-      description: { [LocalizedString.EN_US]: 'Can 2 intersects Green Garage' },
+      name: tr('Can 2 Intersects Green Garage'),
+      description: tr('Can 2 intersects Green Garage'),
     },
     can9Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 9 Intersects Blue Garage' },
-      description: { [LocalizedString.EN_US]: 'Can 9 intersects Blue Garage' },
+      name: tr('Can 9 Intersects Blue Garage'),
+      description: tr('Can 9 intersects Blue Garage'),
     },
     can9IntersectsPurple: {
-      name: { [LocalizedString.EN_US]: 'Can 9 Intersects Purple Garage' },
-      description: { [LocalizedString.EN_US]: 'Can 9 intersects Purple Garage' },
+      name: tr('Can 9 Intersects Purple Garage'),
+      description: tr('Can 9 intersects Purple Garage'),
     },
     can10Intersects: {
-      name: { [LocalizedString.EN_US]: 'Can 10 Intersects Yellow Garage' },
-      description: { [LocalizedString.EN_US]: 'Can 10 intersects Yellow Garage' },
+      name: tr('Can 10 Intersects Yellow Garage'),
+      description: tr('Can 10 intersects Yellow Garage'),
     },
   },
   success: {
@@ -139,15 +137,15 @@ export default {
     rootId: 'completion',
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'can2Intersects', name: { [LocalizedString.EN_US]: 'Place can 2 in green garage' } },
-    { exprId: 'can9Intersects', name: { [LocalizedString.EN_US]: 'Place can 9 in blue garage' } },
-    { exprId: 'can10Intersects', name: { [LocalizedString.EN_US]: 'Place can 10 in yellow garage' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'can2Intersects', name: tr('Place can 2 in green garage') },
+    { exprId: 'can9Intersects', name: tr('Place can 9 in blue garage') },
+    { exprId: 'can10Intersects', name: tr('Place can 10 in yellow garage') },
   ],
   failureGoals: [
-    { exprId: 'can2NotUpright', name: { [LocalizedString.EN_US]: 'Can 2 not upright in green garage' } },
-    { exprId: 'can9NotUpright', name: { [LocalizedString.EN_US]: 'Can 9 not upright in blue garage' } },
-    { exprId: 'can10NotUpright', name: { [LocalizedString.EN_US]: 'Can 10 not upright in yellow garage' } },
+    { exprId: 'can2NotUpright', name: tr('Can 2 not upright in green garage') },
+    { exprId: 'can9NotUpright', name: tr('Can 9 not upright in blue garage') },
+    { exprId: 'can10NotUpright', name: tr('Can 10 not upright in yellow garage') },
   ],
 
   sceneId: 'jbc7',

--- a/src/simulator/definitions/challenges/jbc8-Bulldozer-Mania.ts
+++ b/src/simulator/definitions/challenges/jbc8-Bulldozer-Mania.ts
@@ -1,14 +1,12 @@
 import Author from "../../../db/Author";
 import Challenge from "../../../state/State/Challenge";
 import Expr from "../../../state/State/Challenge/Expr";
-import LocalizedString from "../../../util/LocalizedString";
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: "JBC Challenge 8" },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 8: Bulldozer Mania`,
-  },
+  name: tr("JBC Challenge 8"),
+  description: tr(`Junior Botball Challenge 8: Bulldozer Mania`),
   author: {
     type: Author.Type.Organization,
     id: "kipr",
@@ -21,28 +19,28 @@ export default {
   defaultLanguage: "c",
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: "Robot not in Start Box" },
-      description: { [LocalizedString.EN_US]: "Robot not in start box" },
+      name: tr("Robot not in Start Box"),
+      description: tr("Robot not in start box"),
     },
     canAUpright: {
-      name: { [LocalizedString.EN_US]: "Can A Upright" },
-      description: { [LocalizedString.EN_US]: "Can A upright behind start line" },
+      name: tr("Can A Upright"),
+      description: tr("Can A upright behind start line"),
     },
     canBUpright: {
-      name: { [LocalizedString.EN_US]: "Can B Upright" },
-      description: { [LocalizedString.EN_US]: "Can B upright behind start line" },
+      name: tr("Can B Upright"),
+      description: tr("Can B upright behind start line"),
     },
     canCUpright: {
-      name: { [LocalizedString.EN_US]: "Can C Upright" },
-      description: { [LocalizedString.EN_US]: "Can C upright behind start line" },
+      name: tr("Can C Upright"),
+      description: tr("Can C upright behind start line"),
     },
     canDUpright: {
-      name: { [LocalizedString.EN_US]: "Can D Upright" },
-      description: { [LocalizedString.EN_US]: "Can D upright behind start line" },
+      name: tr("Can D Upright"),
+      description: tr("Can D upright behind start line"),
     },
     canEUpright: {
-      name: { [LocalizedString.EN_US]: "Can E Upright" },
-      description: { [LocalizedString.EN_US]: "Can E upright behind start line" },
+      name: tr("Can E Upright"),
+      description: tr("Can E upright behind start line"),
     },
   },
   success: {
@@ -96,12 +94,12 @@ export default {
     rootId: "completion",
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'canAUpright', name: { [LocalizedString.EN_US]: 'First can upright in start box' } },
-    { exprId: 'canBUpright', name: { [LocalizedString.EN_US]: 'Second can upright in start box' } },
-    { exprId: 'canCUpright', name: { [LocalizedString.EN_US]: 'Third can upright in start box' } },
-    { exprId: 'canDUpright', name: { [LocalizedString.EN_US]: 'Fourth can upright in start box' } },
-    { exprId: 'canEUpright', name: { [LocalizedString.EN_US]: 'Fifth can upright in start box' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'canAUpright', name: tr('First can upright in start box') },
+    { exprId: 'canBUpright', name: tr('Second can upright in start box') },
+    { exprId: 'canCUpright', name: tr('Third can upright in start box') },
+    { exprId: 'canDUpright', name: tr('Fourth can upright in start box') },
+    { exprId: 'canEUpright', name: tr('Fifth can upright in start box') },
   ],
   sceneId: "jbc8",
 } as Challenge;

--- a/src/simulator/definitions/challenges/jbc9-Cover-Your-Bases.ts
+++ b/src/simulator/definitions/challenges/jbc9-Cover-Your-Bases.ts
@@ -1,14 +1,12 @@
 import Author from '../../../db/Author';
 import Challenge from '../../../state/State/Challenge';
 import Expr from '../../../state/State/Challenge/Expr';
-import LocalizedString from '../../../util/LocalizedString';
 import ProgrammingLanguage from "../../../programming/compiler/ProgrammingLanguage";
+import tr from '@i18n';
 
 export default {
-  name: { [LocalizedString.EN_US]: 'JBC Challenge 9' },
-  description: {
-    [LocalizedString.EN_US]: `Junior Botball Challenge 9: Cover Your Bases`,
-  },
+  name: tr('JBC Challenge 9'),
+  description: tr(`Junior Botball Challenge 9: Cover Your Bases`),
   author: {
     type: Author.Type.Organization,
     id: 'kipr',
@@ -21,48 +19,48 @@ export default {
   defaultLanguage: 'c',
   events: {
     notInStartBox: {
-      name: { [LocalizedString.EN_US]: 'Robot not in Start Box' },
-      description: { [LocalizedString.EN_US]: 'Robot not in start box' },
+      name: tr('Robot not in Start Box'),
+      description: tr('Robot not in start box'),
     },
     canAUpright: {
-      name: { [LocalizedString.EN_US]: 'Can A Upright' },
-      description: { [LocalizedString.EN_US]: 'Can A upright in a circle', },
+      name: tr('Can A Upright'),
+      description: tr('Can A upright in a circle'),
     },
     canBUpright: {
-      name: { [LocalizedString.EN_US]: 'Can B Upright' },
-      description: { [LocalizedString.EN_US]: 'Can B upright in a circle', },
+      name: tr('Can B Upright'),
+      description: tr('Can B upright in a circle'),
     },
     canCUpright: {
-      name: { [LocalizedString.EN_US]: 'Can C Upright' },
-      description: { [LocalizedString.EN_US]: 'Can C upright in a circle', },
+      name: tr('Can C Upright'),
+      description: tr('Can C upright in a circle'),
     },
     canDUpright: {
-      name: { [LocalizedString.EN_US]: 'Can D Upright' },
-      description: { [LocalizedString.EN_US]: 'Can D upright in a circle', },
+      name: tr('Can D Upright'),
+      description: tr('Can D upright in a circle'),
     },
     canEUpright: {
-      name: { [LocalizedString.EN_US]: 'Can E Upright' },
-      description: { [LocalizedString.EN_US]: 'Can E upright in a circle', },
+      name: tr('Can E Upright'),
+      description: tr('Can E upright in a circle'),
     },
     baseACovered: {
-      name: { [LocalizedString.EN_US]: 'Base A Covered' },
-      description: { [LocalizedString.EN_US]: 'Base A covered by a can', },
+      name: tr('Base A Covered'),
+      description: tr('Base A covered by a can'),
     },
     baseBCovered: {
-      name: { [LocalizedString.EN_US]: 'Base B Covered' },
-      description: { [LocalizedString.EN_US]: 'Base B covered by a can', },
+      name: tr('Base B Covered'),
+      description: tr('Base B covered by a can'),
     },
     baseCCovered: {
-      name: { [LocalizedString.EN_US]: 'Base C Covered' },
-      description: { [LocalizedString.EN_US]: 'Base C covered by a can', },
+      name: tr('Base C Covered'),
+      description: tr('Base C covered by a can'),
     },
     baseDCovered: {
-      name: { [LocalizedString.EN_US]: 'Base D Covered' },
-      description: { [LocalizedString.EN_US]: 'Base D covered by a can', },
+      name: tr('Base D Covered'),
+      description: tr('Base D covered by a can'),
     },
     baseECovered: {
-      name: { [LocalizedString.EN_US]: 'Base E Covered' },
-      description: { [LocalizedString.EN_US]: 'Base E covered by a can', },
+      name: tr('Base E Covered'),
+      description: tr('Base E covered by a can'),
     },
   },
   success: {
@@ -162,19 +160,19 @@ export default {
     rootId: 'completion',
   },
   successGoals: [
-    { exprId: 'inStartBoxOnce', name: { [LocalizedString.EN_US]: 'Start in the Start Box' } },
-    { exprId: 'baseACovered', name: { [LocalizedString.EN_US]: 'Cover base A' } },
-    { exprId: 'baseBCovered', name: { [LocalizedString.EN_US]: 'Cover base B' } },
-    { exprId: 'baseCCovered', name: { [LocalizedString.EN_US]: 'Cover base C' } },
-    { exprId: 'baseDCovered', name: { [LocalizedString.EN_US]: 'Cover base D' } },
-    { exprId: 'baseECovered', name: { [LocalizedString.EN_US]: 'Cover base E' } },
+    { exprId: 'inStartBoxOnce', name: tr('Start in the Start Box') },
+    { exprId: 'baseACovered', name: tr('Cover base A') },
+    { exprId: 'baseBCovered', name: tr('Cover base B') },
+    { exprId: 'baseCCovered', name: tr('Cover base C') },
+    { exprId: 'baseDCovered', name: tr('Cover base D') },
+    { exprId: 'baseECovered', name: tr('Cover base E') },
   ],
   failureGoals: [
-    { exprId: 'canANotUpright', name: { [LocalizedString.EN_US]: 'Can A not upright' } },
-    { exprId: 'canBNotUpright', name: { [LocalizedString.EN_US]: 'Can B not upright' } },
-    { exprId: 'canCNotUpright', name: { [LocalizedString.EN_US]: 'Can C not upright' } },
-    { exprId: 'canDNotUpright', name: { [LocalizedString.EN_US]: 'Can D not upright' } },
-    { exprId: 'canENotUpright', name: { [LocalizedString.EN_US]: 'Can E not upright' } },
+    { exprId: 'canANotUpright', name: tr('Can A not upright') },
+    { exprId: 'canBNotUpright', name: tr('Can B not upright') },
+    { exprId: 'canCNotUpright', name: tr('Can C not upright') },
+    { exprId: 'canDNotUpright', name: tr('Can D not upright') },
+    { exprId: 'canENotUpright', name: tr('Can E not upright') },
   ],
   sceneId: 'jbc9',
 } as Challenge;


### PR DESCRIPTION
## Summary
- replace `[LocalizedString.EN_US]` mapping with `tr()` in all challenge definitions
- remove `LocalizedString` imports and add `tr` import

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*


------
https://chatgpt.com/codex/tasks/task_e_68a8995219cc832baa54e6fb7dd9f521