### PR TITLE
Fix mat B ground

### DIFF
--- a/src/simulator/definitions/scenes/jbcBase.ts
+++ b/src/simulator/definitions/scenes/jbcBase.ts
@@ -175,6 +175,7 @@ export function createBaseSceneSurfaceB(): Scene {
         visible: true,
         physics: {
           type: 'box',
+          motionType: PhysicsMotionType.STATIC,
           restitution: 0.1,
           friction: 10,
         },


### PR DESCRIPTION
This should have been part of the physics PR, but I forgot. Fixes an issue with the ground in JBC Mat B scenes.