### PR TITLE
Fix AI JSON error and improve error handling

### DIFF
--- a/express.js
+++ b/express.js
@@ -43,8 +43,15 @@ app.use(session({
   name: 'kipr_session'
 }));
 
-// CSRF protection
-app.use(csrf());
+// CSRF protection - skip for API routes that use Bearer token authentication
+app.use((req, res, next) => {
+  // Skip CSRF for API routes that use Bearer tokens (CSRF-safe by design)
+  if (req.path.startsWith('/api/')) {
+    return next();
+  }
+  // Apply CSRF protection to other routes
+  csrf()(req, res, next);
+});
 
 // Metrics collection
 const metrics = require('./metrics');


### PR DESCRIPTION
### Problem
Users were encountering a JSON parsing error when using the AI tutor:
### Root Cause
The CSRF protection middleware was being applied globally to all routes, including API endpoints that use Bearer token authentication. When CSRF validation failed (no CSRF token in requests), the middleware returned HTML error pages instead of JSON responses, causing JSON parsing failures on the client.
### Solution
1. Server-side (express.js): Modified CSRF protection to skip API routes (/api/*) that use Bearer tokens, which are inherently CSRF-safe since tokens are in the Authorization header, not cookies.
2. Client-side (src/util/ai.ts): Improved error handling to gracefully handle non-JSON responses by reading response text first before attempting JSON parsing, providing clearer error messages when issues occur.

### Testing
- Start the server
- Use the AI tutor to send a message
- Verify the AI responds without JSON parsing errors
- Verify error messages are clear and helpful if other issues occur