### PR TITLE
Scene name overlay

### DIFF
--- a/src/components/Layout/Layout.ts
+++ b/src/components/Layout/Layout.ts
@@ -34,6 +34,7 @@ export type LayoutEditorTarget = LayoutEditorTarget.Robot;
 
 export interface LayoutProps extends StyleProps, ThemeProps {
   sceneId: string;
+  layout: Layout;
   editorTarget: LayoutEditorTarget;
   console: StyledText;
   messages: Message[];

--- a/src/components/Layout/OverlayLayout.tsx
+++ b/src/components/Layout/OverlayLayout.tsx
@@ -8,7 +8,7 @@ import { Editor, createEditorBarComponents, EditorBarTarget } from '../Editor';
 import World from '../World';
 
 import { Info } from '../Info';
-import { LayoutEditorTarget, LayoutProps } from './Layout';
+import { Layout, LayoutEditorTarget, LayoutProps } from './Layout';
 import SimulatorArea from './SimulatorArea';
 import { Theme, ThemeProps } from '../constants/theme';
 import Widget, { Mode, Size, WidgetProps } from '../interface/Widget';
@@ -75,6 +75,33 @@ const transparentStyling = (theme: Theme): React.CSSProperties => ({
   backgroundColor: theme.transparentBackgroundColor(0.95),
   backdropFilter: 'blur(16px)'
 });
+
+// Overlay positioned centered in column 2 (the space that appears when Editor is miniature)
+// The grid is: [padding] [4fr] [gap] [5fr] [gap] [350px] [padding]
+// Column 2 is 5fr wide. When Editor is miniature, it only takes column 1, leaving column 2 visible.
+// We place the overlay as a grid item in column 2 and center it horizontally, with width fit-content
+const SceneNameOverlay = styled('div', (props: ThemeProps) => ({
+  gridColumn: '2',
+  gridRow: '1',
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'center',
+  paddingTop: `${props.theme.widget.padding}px`,
+  pointerEvents: 'none',
+  padding: `${props.theme.itemPadding}px ${props.theme.itemPadding * 2}px`,
+  borderRadius: `${props.theme.borderRadius}px`,
+  backgroundColor: props.theme.transparentBackgroundColor(0.95),
+  backdropFilter: 'blur(16px)',
+  color: props.theme.color,
+  fontSize: '1.2em',
+  fontWeight: 600,
+  whiteSpace: 'nowrap',
+  border: `1px solid ${props.theme.borderColor}`,
+  alignSelf: 'start',
+  justifySelf: 'center',
+  width: 'fit-content',
+  zIndex: 0,
+}));
 
 const ConsoleWidget = styled(Widget, (props: WidgetProps & { $challenge?: boolean; }) => {
   const size = props.sizes[props.size];
@@ -350,6 +377,7 @@ export class OverlayLayout extends React.PureComponent<Props & ReduxOverlayLayou
       editorRef,
       robots,
       sceneId,
+      layout,
       scene,
       onNodeAdd,
       onNodeChange,
@@ -427,6 +455,8 @@ export class OverlayLayout extends React.PureComponent<Props & ReduxOverlayLayou
       robotNode = Dict.unique(robots);
     }
 
+    const sceneName = latestScene ? LocalizedString.lookup(latestScene.name, locale) : '';
+
     return (
       <Container style={style} className={className}>
         <SimulatorAreaContainer>
@@ -438,6 +468,11 @@ export class OverlayLayout extends React.PureComponent<Props & ReduxOverlayLayou
           />
         </SimulatorAreaContainer>
         <Overlay theme={theme} $challenge={!!challengeState}>
+          {sceneName && (
+            <SceneNameOverlay theme={theme}>
+              {sceneName}
+            </SceneNameOverlay>
+          )}
           <EditorWidget
             {...commonProps}
             name={LocalizedString.lookup(tr('Editor'), locale)}

--- a/src/components/Layout/SideLayout.tsx
+++ b/src/components/Layout/SideLayout.tsx
@@ -9,7 +9,7 @@ import { Editor, createEditorBarComponents, EditorBarTarget } from '../Editor';
 import World from '../World';
 
 import { Info } from '../Info';
-import { LayoutEditorTarget, LayoutProps } from './Layout';
+import { Layout, LayoutEditorTarget, LayoutProps } from './Layout';
 import SimulatorArea from './SimulatorArea';
 import { TabBar } from './TabBar';
 import Widget, { Mode, Size } from '../interface/Widget';
@@ -26,6 +26,7 @@ import { ReferenceFramewUnits } from '../../util/math/unitMath';
 
 import tr from '@i18n';
 import LocalizedString from '../../util/LocalizedString';
+import { ThemeProps } from '../constants/theme';
 
 
 const sizeDict = (sizes: Size[]) => {
@@ -82,6 +83,7 @@ const SideBar = styled('div', {
 const SimulatorAreaContainer = styled('div', {
   display: 'flex',
   flex: '1 1',
+  position: 'relative',
 });
 const SimultorWidgetContainer = styled('div', {
   display: 'flex',
@@ -102,6 +104,24 @@ const SimulatorWidget = styled(Widget, {
 const FlexConsole = styled(Console, {
   flex: '1 1',
 });
+
+const SceneNameOverlay = styled('div', (props: ThemeProps) => ({
+  position: 'absolute',
+  top: `${props.theme.widget.padding}px`,
+  left: '50%',
+  transform: 'translateX(-50%)',
+  pointerEvents: 'none',
+  zIndex: 1,
+  padding: `${props.theme.itemPadding}px ${props.theme.itemPadding * 2}px`,
+  borderRadius: `${props.theme.borderRadius}px`,
+  backgroundColor: props.theme.transparentBackgroundColor(0.95),
+  backdropFilter: 'blur(16px)',
+  color: props.theme.color,
+  fontSize: '1.2em',
+  fontWeight: 600,
+  whiteSpace: 'nowrap',
+  border: `1px solid ${props.theme.borderColor}`,
+}));
 
 const SideBarMinimizedTab = -1;
 
@@ -183,6 +203,7 @@ export class SideLayout extends React.PureComponent<Props & ReduxSideLayoutProps
       editorRef,
       robots,
       sceneId,
+      layout,
       scene,
       onNodeAdd,
       onNodeChange,
@@ -371,7 +392,15 @@ export class SideLayout extends React.PureComponent<Props & ReduxSideLayoutProps
     }
 
 
+    const latestScene = Async.latestValue(scene);
+    const sceneName = latestScene ? LocalizedString.lookup(latestScene.name, locale) : '';
+
     const simulator = <SimulatorAreaContainer>
+      {sceneName && (
+        <SceneNameOverlay theme={theme}>
+          {sceneName}
+        </SceneNameOverlay>
+      )}
       <SimulatorArea
         theme={theme}
         key='simulator'

--- a/src/pages/ChallengeRoot.tsx
+++ b/src/pages/ChallengeRoot.tsx
@@ -852,6 +852,7 @@ class Root extends React.Component<Props, State> {
       onDownloadCode: this.onDownloadClick_,
       editorRef: this.editorRef,
       sceneId: undefined,
+      layout,
       scene: workingScene,
       onNodeAdd: this.onNodeAdd_,
       onNodeChange: this.onNodeChange_,

--- a/src/pages/Root.tsx
+++ b/src/pages/Root.tsx
@@ -692,6 +692,7 @@ class Root extends React.Component<Props, State> {
       onResetCode: this.onResetCode_,
       editorRef: this.editorRef,
       sceneId,
+      layout,
       scene,
       onNodeAdd: this.props.onNodeAdd,
       onNodeChange: this.props.onNodeChange,


### PR DESCRIPTION
Add scene name overlay to side and overlay layouts. It should be centered in either view and remains static and behind other widgets if they are expanded in overlay layout. Issue #361 