### PR TITLE
Github issue 588 fix

### DIFF
--- a/src/components/Dialog/OpenSceneDialog.tsx
+++ b/src/components/Dialog/OpenSceneDialog.tsx
@@ -144,7 +144,6 @@ class OpenSceneDialog extends React.PureComponent<Props, SelectSceneDialogState>
     
     if (selectedScene) {
       this.props.navigate(`/scene/${selectedSceneId}`);
-      location.reload();
     }
     this.props.onClose();
   };

--- a/src/lms/CurriculumPage.tsx
+++ b/src/lms/CurriculumPage.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { styled } from 'styletron-react';
 import LocalizedString from '../util/LocalizedString';
 import { DARK, LIGHT, Theme, ThemeProps } from '../components/constants/theme';
+import { withNavigate, WithNavigateProps } from '../util/withNavigate';
 
 import tr from '@i18n';
 import { faHome, faSchool, faSchoolCircleCheck } from '@fortawesome/free-solid-svg-icons';
@@ -30,7 +31,6 @@ export interface CurriculumPagePrivateProps extends ThemeProps {
   userId: string;
   myAssignments: Set<string>;
   onMyAssignmentsChange: (myAssignments: Set<string>) => void;
-  onAddPluginsClick: () => void;
 }
 
 const Container = styled('div', ({ $theme }: { $theme: Theme }) => ({
@@ -99,9 +99,9 @@ const CurriculumPage = ({
   assignments,
   myAssignments,
   onMyAssignmentsChange,
-  onAddPluginsClick,
+  navigate,
   userId
-}: CurriculumPagePublicProps & CurriculumPagePrivateProps) => {
+}: CurriculumPagePublicProps & CurriculumPagePrivateProps & WithNavigateProps) => {
   const [tabIndex, setTabIndex] = React.useState(0);
   const [isStandardsAligned, setIsStandardsAligned] = React.useState(false);
   const [subjectsSelected, setSubjectsSelected] = React.useState<Set<Subject>>(new Set());
@@ -125,7 +125,7 @@ const CurriculumPage = ({
           $theme={theme}
           icon={faHome}
           onClick={() => {
-            window.location.pathname = '/';
+            navigate('/');
           }}
         />
 
@@ -135,7 +135,7 @@ const CurriculumPage = ({
           onIndexChange={setTabIndex}
           theme={theme}
         />
-        <AddBotballPluginButton $theme={theme} onClick={onAddPluginsClick}>
+        <AddBotballPluginButton $theme={theme} onClick={() => window.location.href = '/lms/plugin'}>
           Add Botball Plugin
         </AddBotballPluginButton>
       </TopBar>
@@ -227,10 +227,7 @@ export default connect((state: State) => {
     myAssignments
   };
 }, (dispatch, ownProps) => ({
-  onAddPluginsClick: () => {
-    window.location.href = '/lms/plugin';
-  },
   onMyAssignmentsChange: (myAssignments: Set<string>) => dispatch(UsersAction.setMyAssignments({
     assignmentIds: Array.from(myAssignments)
   }))
-}))(CurriculumPage) as React.ComponentType<CurriculumPagePublicProps>;
+}))(withNavigate(CurriculumPage)) as React.ComponentType<CurriculumPagePublicProps>;

--- a/src/pages/ChallengeRoot.tsx
+++ b/src/pages/ChallengeRoot.tsx
@@ -105,8 +105,6 @@ interface RootPrivateProps {
   onDocumentationSetLanguage: (language: 'c' | 'python') => void;
   onDocumentationGoToFuzzy: (query: string, language: 'c' | 'python') => void;
 
-  goToLogin: () => void;
-
   onAiClick: () => void;
   onAskTutorClick: (query: SendMessageParams) => void;
 }
@@ -686,12 +684,12 @@ class Root extends React.Component<Props, State> {
 
   onLogoutClick = () => {
     void signOutOfApp().then(() => {
-      this.props.goToLogin();
+      window.location.href = `/login?from=${window.location.pathname}`;
     });
   };
 
   onDashboardClick = () => {
-    window.location.href = '/';
+    this.props.navigate('/');
   };
 
 
@@ -735,7 +733,7 @@ class Root extends React.Component<Props, State> {
   };
 
   private onEndChallengeClick_ = () => {
-    window.location.href = `/scene/${this.props.params.challengeId}`;
+    this.props.navigate(`/scene/${this.props.params.challengeId}`);
   };
 
   private onResetCode_ = () => {
@@ -1026,9 +1024,6 @@ const ConnectedChallengeRoot = connect((state: ReduxState, { params: { challenge
   onDocumentationPush: (location: DocumentationLocation) => dispatch(DocumentationAction.pushLocation({ location })),
   onDocumentationSetLanguage: (language: 'c' | 'python') => dispatch(DocumentationAction.setLanguage({ language })),
   onDocumentationGoToFuzzy: (query: string, language: 'c' | 'python') => dispatch(DocumentationAction.goToFuzzy({ query, language })),
-  goToLogin: () => {
-    window.location.href = `/login?from=${window.location.pathname}`;
-  },
   onAiClick: () => dispatch(AiAction.TOGGLE),
   onAskTutorClick: (params: SendMessageParams) => sendMessage(dispatch, params),
 }))(withNavigate(Root)) as React.ComponentType<RootPublicProps>;

--- a/src/pages/Root.tsx
+++ b/src/pages/Root.tsx
@@ -112,8 +112,6 @@ interface RootPrivateProps {
 
   unfailScene: (id: string) => void;
 
-  goToLogin: () => void;
-
   selectedScriptId?: string;
   selectedScript?: Script;
 
@@ -460,7 +458,7 @@ class Root extends React.Component<Props, State> {
   };
 
   private onStartChallengeClick_ = () => {
-    window.location.href = `/challenge/${this.props.params.sceneId}`;
+    this.props.navigate(`/challenge/${this.props.params.sceneId}`);
   };
   
   private onClearConsole_ = () => {
@@ -523,12 +521,12 @@ class Root extends React.Component<Props, State> {
 
   onLogoutClick = () => {
     void signOutOfApp().then(() => {
-      this.props.goToLogin();
+      window.location.href = `/login?from=${window.location.pathname}`;
     });
   };
 
   onDashboardClick = () => {
-    window.location.href = '/';
+    this.props.navigate('/');
   };
 
 
@@ -952,9 +950,6 @@ const ConnectedRoot = connect((state: ReduxState, { params: { sceneId, challenge
   onSaveScene: (sceneId: string) => dispatch(ScenesAction.saveScene({ sceneId })),
   onSetScenePartial: (partialScene: Partial<Scene>) => dispatch(ScenesAction.setScenePartial({ sceneId, partialScene })),
   unfailScene: (sceneId: string) => dispatch(ScenesAction.unfailScene({ sceneId })),
-  goToLogin: () => {
-    window.location.href = `/login?from=${window.location.pathname}`;
-  },
   onScriptChange: (scriptId: string, script: Script) => {
     dispatch(ScenesAction.setScript({ sceneId, scriptId, script }));
   },


### PR DESCRIPTION
Fixes GitHub issue 588 by replacing full page refreshes with client-side navigation where appropriate to improve user experience.

This PR addresses unnecessary full page reloads after certain actions, particularly when opening a new scene, by leveraging React Router's `navigate` function for internal application routing. Actions like logout or navigating to the LMS plugin, which are distinct application entry points, continue to use `window.location.href` for a full refresh.

---
<a href="https://cursor.com/background-agent?bcId=bc-3dbf5c53-4b39-457f-beda-fc7d86ecce73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3dbf5c53-4b39-457f-beda-fc7d86ecce73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

