### PR TITLE
Fix overlay restore behavior when minimizing Editor or Console

### DIFF
--- a/src/components/Layout/OverlayLayout.tsx
+++ b/src/components/Layout/OverlayLayout.tsx
@@ -252,7 +252,9 @@ export class OverlayLayout extends React.PureComponent<Props & ReduxOverlayLayou
         challengeSize = Size.Type.Minimized;
         break;
       }
-      case Size.Type.Partial: {
+      case Size.Type.Partial:
+      case Size.Type.Miniature:
+      case Size.Type.Minimized: {
         if (infoSize === Size.Type.Minimized) infoSize = Size.Type.Partial;
         if (worldSize === Size.Type.Minimized) worldSize = Size.Type.Partial;
         if (consoleSize === Size.Type.Minimized) consoleSize = Size.Type.Miniature;
@@ -301,7 +303,9 @@ export class OverlayLayout extends React.PureComponent<Props & ReduxOverlayLayou
         challengeSize = Size.Type.Minimized;
         break;
       }
-      case Size.Type.Partial: {
+      case Size.Type.Partial:
+      case Size.Type.Miniature:
+      case Size.Type.Minimized: {
         if (infoSize === Size.Type.Minimized) infoSize = Size.Type.Partial;
         if (worldSize === Size.Type.Minimized) worldSize = Size.Type.Partial;
         if (editorSize === Size.Type.Minimized) editorSize = Size.Type.Partial;


### PR DESCRIPTION
## Summary
Fixes #362 by ensuring that when the Editor or Console widgets are switched from Maximized to Miniature or Minimized states, the other hidden overlays (World, Info, Challenge) are restored. Previously, they were only restored when switching to the Partial state.

## Test plan
1. Open the Simulator.
2. Maximize the Editor widget (expand to full screen).
3. Verify that other widgets (World, Info, etc.) are hidden.
4. Minimize the Editor widget fully (click 'X') or switch to Miniature (double arrow).
5. Verify that the other widgets (World, Info, etc.) reappear.
6. Repeat the same steps for the Console widget.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures hidden overlays are restored when leaving a maximized Editor or Console via minimize or miniature states, not only when switching to partial.
> 
> - Extend restore logic in `onEditorSizeChange_` and `onConsoleSizeChange_` to handle `Miniature` and `Minimized` alongside `Partial`
> - When Editor/Console is maximized, other widgets are minimized; when changed to miniature/minimized/partial, previously minimized `Info`, `World`, and `Challenge` (and the counterpart widget) are restored
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c55d0d70d02ff014e483fd00bc0f157b75f4748. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->