### PR TITLE
Restore widget sizes in all cases

### DIFF
--- a/src/components/Layout/OverlayLayout.tsx
+++ b/src/components/Layout/OverlayLayout.tsx
@@ -252,7 +252,9 @@ export class OverlayLayout extends React.PureComponent<Props & ReduxOverlayLayou
         challengeSize = Size.Type.Minimized;
         break;
       }
-      case Size.Type.Partial: {
+      case Size.Type.Partial:
+      case Size.Type.Miniature:
+      case Size.Type.Minimized: {
         if (infoSize === Size.Type.Minimized) infoSize = Size.Type.Partial;
         if (worldSize === Size.Type.Minimized) worldSize = Size.Type.Partial;
         if (consoleSize === Size.Type.Minimized) consoleSize = Size.Type.Miniature;
@@ -301,10 +303,12 @@ export class OverlayLayout extends React.PureComponent<Props & ReduxOverlayLayou
         challengeSize = Size.Type.Minimized;
         break;
       }
-      case Size.Type.Partial: {
+      case Size.Type.Partial:
+      case Size.Type.Miniature:
+      case Size.Type.Minimized: {
         if (infoSize === Size.Type.Minimized) infoSize = Size.Type.Partial;
         if (worldSize === Size.Type.Minimized) worldSize = Size.Type.Partial;
-        if (editorSize === Size.Type.Minimized) editorSize = Size.Type.Partial;
+        if (editorSize === Size.Type.Minimized) editorSize = Size.Type.Miniature;
         if (challengeSize === Size.Type.Minimized) challengeSize = Size.Type.Partial;
         break;
       }


### PR DESCRIPTION
Fix #362 by covering all cases when changing editor or console size. All other widgets are restored to default positions and sizes. It does not store positions: if the user expanded the console, then maximized and minimized the editor, the console will shrink back to it's original position. If we want to fix that, I think it should be a separate issue.