### PR TITLE
Clear highlight on language change

### DIFF
--- a/src/pages/ChallengeRoot.tsx
+++ b/src/pages/ChallengeRoot.tsx
@@ -477,6 +477,9 @@ class Root extends React.Component<Props, State> {
   private onActiveLanguageChange_ = (language: ProgrammingLanguage) => {
     this.props.onChallengeCompletionSetCurrentLanguage(language);
 
+    // Clear compilation messages when switching languages to prevent stale error highlights
+    this.setState({ messages: [] });
+
     this.scheduleSaveChallengeCompletion_();
   };
 

--- a/src/pages/Root.tsx
+++ b/src/pages/Root.tsx
@@ -268,7 +268,8 @@ class Root extends React.Component<Props, State> {
 
   private onActiveLanguageChange_ = (language: ProgrammingLanguage) => {
     this.setState({
-      activeLanguage: language
+      activeLanguage: language,
+      messages: [],
     }, () => {
       this.props.onDocumentationSetLanguage(language === 'python' ? 'python' : 'c');
     });


### PR DESCRIPTION
Clear compilation messages on language change to prevent stale error highlights from persisting.

Previously, error highlights from C/C++ compilation would remain visible in the editor even after switching to Python, as the `messages` array was not reset.

Fixes #472.

---
<a href="https://cursor.com/background-agent?bcId=bc-a42ec703-e80d-4dc1-82a8-bec53eda0219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a42ec703-e80d-4dc1-82a8-bec53eda0219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

