### PR TITLE
Ensure that mats A and B are mutually exclusive in the sandbox

### DIFF
--- a/src/components/World/index.tsx
+++ b/src/components/World/index.tsx
@@ -384,6 +384,26 @@ class World extends React.PureComponent<Props, State> {
       ...originalNode,
       visible: visibility,
     });
+
+    // Make matA and matB visibility mutually exclusive
+    // When one becomes visible, hide the other
+    if (visibility && (id === 'matA' || id === 'matB')) {
+      const otherMatId = id === 'matA' ? 'matB' : 'matA';
+      const workingScene = Async.latestValue(this.props.scene);
+      const otherMatNode = workingScene.nodes[otherMatId];
+      
+      if (otherMatNode && otherMatNode.visible) {
+        let otherOriginalNode = Async.previousValue(this.props.scene).nodes[otherMatId];
+        if (!otherOriginalNode) {
+          otherOriginalNode = Async.latestValue(this.props.scene).nodes[otherMatId];
+        }
+        
+        this.props.onNodeChange(otherMatId, {
+          ...otherOriginalNode,
+          visible: false,
+        });
+      }
+    }
   };
 
   render() {


### PR DESCRIPTION
Fixes #630. Previously, the reflectance sensor seemed to "prefer" reading values from mat A even when mat B appeared to be on top. Adds a small check to the UI toggle to disable one when the other is enabled. This does not apply to visibility changes in scene scripting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures only one mat is visible at a time in the UI.
> 
> - Enhances `onItemVisibilityChange_` in `World/index.tsx` to auto-hide the other mat (`matA`/`matB`) when one is set visible, using `Async.previousValue`/`Async.latestValue` to update node visibility safely.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e8bb0d1537405588932f89adc0d5b0cf25afaee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->