### PR TITLE
Challenge event callbacks now derive eventStates

### DIFF
--- a/src/db/Builder.ts
+++ b/src/db/Builder.ts
@@ -4,11 +4,13 @@ import { ChallengeCompletionsAction, ChallengesAction, ClassroomsAction, ScenesA
 import { LimitedChallengeCompletionsAction } from '../state/reducer/limitedChallengeCompletions';
 import Async from '../state/State/Async';
 import { AsyncChallenge } from '../state/State/Challenge';
+import ChallengeCompletion from '../state/State/ChallengeCompletion';
 import { AsyncLimitedChallenge } from '../state/State/LimitedChallenge';
 import { AsyncChallengeCompletion } from '../state/State/ChallengeCompletion';
-import { AsyncLimitedChallengeCompletion } from '../state/State/LimitedChallengeCompletion';
+import LimitedChallengeCompletion, { AsyncLimitedChallengeCompletion } from '../state/State/LimitedChallengeCompletion';
 import { AsyncScene } from '../state/State/Scene';
 import { AsyncClassroom } from 'state/State/Classroom';
+import DbError from '../db/Error';
 
 export class ChallengeBuilder {
   private id_: string;
@@ -50,6 +52,14 @@ export class ChallengeCompletionBuilder {
 
     if (!challengeCompletion || challengeCompletion.type === Async.Type.Unloaded) {
       builder.loadChallengeCompletion_(id);
+    } else if (
+      challengeCompletion.type === Async.Type.LoadFailed &&
+      challengeCompletion.error.code === DbError.CODE_NOT_FOUND
+    ) {
+      builder.createChallengeCompletionIfMissing_(id);
+      if (!builder.challengeCompletions[id]) {
+        builder.addChallengeCompletion_(id, challengeCompletion);
+      }
     } else {
       builder.addChallengeCompletion_(id, challengeCompletion);
     }
@@ -108,6 +118,14 @@ export class LimitedChallengeCompletionBuilder {
 
     if (!challengeCompletion || challengeCompletion.type === Async.Type.Unloaded) {
       builder.loadLimitedChallengeCompletion_(id);
+    } else if (
+      challengeCompletion.type === Async.Type.LoadFailed &&
+      challengeCompletion.error.code === DbError.CODE_NOT_FOUND
+    ) {
+      builder.createLimitedChallengeCompletionIfMissing_(id);
+      if (!builder.limitedChallengeCompletions[id]) {
+        builder.addLimitedChallengeCompletion_(id, challengeCompletion);
+      }
     } else {
       builder.addLimitedChallengeCompletion_(id, challengeCompletion);
     }
@@ -219,6 +237,19 @@ class Builder {
     this.challengeCompletions_[id] = Async.unloaded({});
   }
 
+  createChallengeCompletionIfMissing_(id: string) {
+    const challenge = Async.latestValue(this.state.challenges[id]);
+    if (!challenge) return;
+
+    const challengeCompletion = {
+      ...ChallengeCompletion.EMPTY,
+      code: challenge.code,
+      currentLanguage: challenge.defaultLanguage,
+    };
+    this.challengeCompletions_[id] = Async.creating({ value: challengeCompletion });
+    store.dispatch(ChallengeCompletionsAction.createChallengeCompletion({ challengeId: id, challengeCompletion }));
+  }
+
   loadClassroom_(id: string) {
     this.classroomsToLoad_.add(id);
     this.classrooms_[id] = Async.unloaded({});
@@ -228,6 +259,19 @@ class Builder {
   loadLimitedChallengeCompletion_(id: string) {
     this.limitedChallengeCompletionsToLoad_.add(id);
     this.limitedChallengeCompletions_[id] = Async.unloaded({});
+  }
+
+  createLimitedChallengeCompletionIfMissing_(id: string) {
+    const challenge = Async.latestValue(this.state.limitedChallenges[id]);
+    if (!challenge) return;
+
+    const challengeCompletion = {
+      ...LimitedChallengeCompletion.EMPTY,
+      code: challenge.code,
+      currentLanguage: challenge.defaultLanguage,
+    };
+    this.limitedChallengeCompletions_[id] = Async.creating({ value: challengeCompletion });
+    store.dispatch(LimitedChallengeCompletionsAction.createLimitedChallengeCompletion({ challengeId: id, challengeCompletion }));
   }
 
   dispatchLoads() {

--- a/src/db/Builder.ts
+++ b/src/db/Builder.ts
@@ -4,9 +4,8 @@ import { ChallengeCompletionsAction, ChallengesAction, ClassroomsAction, ScenesA
 import { LimitedChallengeCompletionsAction } from '../state/reducer/limitedChallengeCompletions';
 import Async from '../state/State/Async';
 import { AsyncChallenge } from '../state/State/Challenge';
-import ChallengeCompletion from '../state/State/ChallengeCompletion';
 import { AsyncLimitedChallenge } from '../state/State/LimitedChallenge';
-import { AsyncChallengeCompletion } from '../state/State/ChallengeCompletion';
+import ChallengeCompletion, { AsyncChallengeCompletion } from '../state/State/ChallengeCompletion';
 import LimitedChallengeCompletion, { AsyncLimitedChallengeCompletion } from '../state/State/LimitedChallengeCompletion';
 import { AsyncScene } from '../state/State/Scene';
 import { AsyncClassroom } from 'state/State/Classroom';

--- a/src/pages/ChallengeRoot.tsx
+++ b/src/pages/ChallengeRoot.tsx
@@ -30,7 +30,7 @@ import { Editor } from '../components/Editor';
 import { Capabilities } from '../components/World';
 
 
-import { State as ReduxState } from '../state';
+import store, { State as ReduxState } from '../state';
 import { ScenesAction, ChallengeCompletionsAction, AiAction } from '../state/reducer';
 
 import { sendMessage, SendMessageParams } from '../util/ai';
@@ -43,7 +43,7 @@ import Camera from '../state/State/Scene/Camera';
 
 import Async from '../state/State/Async';
 import { AsyncChallenge } from '../state/State/Challenge';
-import ChallengeCompletion, { AsyncChallengeCompletion } from '../state/State/ChallengeCompletion';
+import { AsyncChallengeCompletion } from '../state/State/ChallengeCompletion';
 import PredicateCompletion from '../state/State/ChallengeCompletion/PredicateCompletion';
 
 import DocumentationLocation from '../state/State/Documentation/DocumentationLocation';
@@ -51,8 +51,6 @@ import DocumentationLocation from '../state/State/Documentation/DocumentationLoc
 import Record from '../db/Record';
 import Selector from '../db/Selector';
 import Builder from '../db/Builder';
-import DbError from '../db/Error';
-
 import { StyledText } from '../util';
 import construct from '../util/redux/construct';
 import Dict from '../util/objectOps/Dict';
@@ -89,7 +87,6 @@ interface RootPrivateProps {
 
   robots: Dict<Robot>;
 
-  onChallengeCompletionCreate: (challengeCompletion: ChallengeCompletion) => void;
   onChallengeCompletionSceneDiffChange: (sceneDiff: OuterObjectPatch<Scene>) => void;
   onChallengeCompletionEventStateRemove: (eventId: string) => void;
   onChallengeCompletionEventStateChange: (eventId: string, eventState: boolean) => void;
@@ -309,12 +306,12 @@ class Root extends React.Component<Props, State> {
   };
 
   private onSetEventValue_ = (eventId: string, value: boolean) => {
-    const { challenge, challengeCompletion } = this.props;
-
-    const latestChallenge = Async.latestValue(challenge);
+    const { challengeId } = this.props.params;
+    const state = store.getState();
+    const latestChallenge = Async.latestValue(state.challenges[challengeId]);
     if (!latestChallenge) return;
 
-    const latestChallengeCompletion = Async.latestValue(challengeCompletion);
+    const latestChallengeCompletion = Async.latestValue(state.challengeCompletions[challengeId]);
     if (!latestChallengeCompletion) return;
 
     const { success, failure } = latestChallenge;
@@ -377,20 +374,6 @@ class Root extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<RootState>): void {
-    const { params: { challengeId }, challenge, challengeCompletion } = this.props;
-
-    if (challengeId && challenge && challengeCompletion && challengeCompletion.type === Async.Type.LoadFailed) {
-      const latestChallenge = Async.latestValue(challenge);
-      if (challengeCompletion.error.code === DbError.CODE_NOT_FOUND && latestChallenge) {
-        console.log('Challenge completion not found');
-        this.props.onChallengeCompletionCreate({
-          ...ChallengeCompletion.EMPTY,
-          code: latestChallenge.code,
-          currentLanguage: latestChallenge.defaultLanguage,
-        });
-      }
-    }
-
     if (this.state.simulatorState.type !== prevState.simulatorState.type) {
       Space.getInstance().sceneBinding.scriptManager.programStatus = this.state.simulatorState.type === SimulatorState.Type.Running ? 'running' : 'stopped';
     }
@@ -1036,9 +1019,6 @@ const ConnectedChallengeRoot = connect((state: ReduxState, { params: { challenge
     robots: Dict.map(state.robots.robots, Async.latestValue),
   };
 }, (dispatch, { params: { challengeId } }: RootPublicProps) => ({
-  onChallengeCompletionCreate: (challengeCompletion: ChallengeCompletion) => {
-    dispatch(ChallengeCompletionsAction.createChallengeCompletion({ challengeId, challengeCompletion }));
-  },
   onChallengeCompletionSceneDiffChange: (sceneDiff: OuterObjectPatch<Scene>) => {
     dispatch(ChallengeCompletionsAction.setSceneDiff({ challengeId, sceneDiff }));
   },

--- a/src/pages/LimitedChallengeRoot.tsx
+++ b/src/pages/LimitedChallengeRoot.tsx
@@ -29,7 +29,7 @@ import Loading from '../components/Loading';
 import { Editor } from '../components/Editor';
 import { Capabilities } from '../components/World';
 
-import { State as ReduxState } from '../state';
+import store, { State as ReduxState } from '../state';
 import { ScenesAction, AiAction } from '../state/reducer';
 
 import { DocumentationAction } from 'ivygate/dist/src/state/reducer/documentation';
@@ -44,13 +44,12 @@ import Camera from '../state/State/Scene/Camera';
 
 import Async from '../state/State/Async';
 import LimitedChallenge, { AsyncLimitedChallenge, LimitedChallengeStatus } from '../state/State/LimitedChallenge';
-import LimitedChallengeCompletion, { AsyncLimitedChallengeCompletion } from '../state/State/LimitedChallengeCompletion';
+import { AsyncLimitedChallengeCompletion } from '../state/State/LimitedChallengeCompletion';
 import PredicateCompletion from '../state/State/ChallengeCompletion/PredicateCompletion';
 import Predicate from '../state/State/Challenge/Predicate';
 
 import DocumentationLocation from '../state/State/Documentation/DocumentationLocation';
 
-import DbError from '../db/Error';
 import Builder from '../db/Builder';
 
 import { StyledText } from '../util';
@@ -87,7 +86,6 @@ interface RootPrivateProps {
 
   robots: Dict<Robot>;
 
-  onChallengeCompletionCreate: (challengeCompletion: LimitedChallengeCompletion) => void;
   onChallengeCompletionSceneDiffChange: (sceneDiff: OuterObjectPatch<Scene>) => void;
   onChallengeCompletionEventStateRemove: (eventId: string) => void;
   onChallengeCompletionEventStateChange: (eventId: string, eventState: boolean) => void;
@@ -318,12 +316,12 @@ class LimitedChallengeRoot extends React.Component<Props, State> {
   };
 
   private onSetEventValue_ = (eventId: string, value: boolean) => {
-    const { challenge, challengeCompletion } = this.props;
-
-    const latestChallenge = Async.latestValue(challenge);
+    const { challengeId } = this.props.params;
+    const state = store.getState();
+    const latestChallenge = Async.latestValue(state.limitedChallenges[challengeId]);
     if (!latestChallenge) return;
 
-    const latestChallengeCompletion = Async.latestValue(challengeCompletion);
+    const latestChallengeCompletion = Async.latestValue(state.limitedChallengeCompletions[challengeId]);
     if (!latestChallengeCompletion) return;
 
     const { success, failure } = latestChallenge;
@@ -417,20 +415,6 @@ class LimitedChallengeRoot extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<RootState>): void {
-    const { params: { challengeId }, challenge, challengeCompletion } = this.props;
-
-    if (challengeId && challenge && challengeCompletion && challengeCompletion.type === Async.Type.LoadFailed) {
-      const latestChallenge = Async.latestValue(challenge);
-      if (challengeCompletion.error.code === DbError.CODE_NOT_FOUND && latestChallenge) {
-        console.log('Limited challenge completion not found');
-        this.props.onChallengeCompletionCreate({
-          ...LimitedChallengeCompletion.EMPTY,
-          code: latestChallenge.code,
-          currentLanguage: latestChallenge.defaultLanguage,
-        });
-      }
-    }
-
     if (this.state.simulatorState.type !== prevState.simulatorState.type) {
       Space.getInstance().sceneBinding.scriptManager.programStatus = this.state.simulatorState.type === SimulatorState.Type.Running ? 'running' : 'stopped';
     }
@@ -1096,9 +1080,6 @@ const ConnectedLimitedChallengeRoot = connect((state: ReduxState, { params: { ch
     robots: Dict.map(state.robots.robots, Async.latestValue),
   };
 }, (dispatch, { params: { challengeId } }: RootPublicProps) => ({
-  onChallengeCompletionCreate: (challengeCompletion: LimitedChallengeCompletion) => {
-    dispatch(LimitedChallengeCompletionsAction.createLimitedChallengeCompletion({ challengeId, challengeCompletion }));
-  },
   onChallengeCompletionSceneDiffChange: (sceneDiff: OuterObjectPatch<Scene>) => {
     dispatch(LimitedChallengeCompletionsAction.setSceneDiff({ challengeId, sceneDiff }));
   },


### PR DESCRIPTION
Fixes a bug caused by React 18's more aggressive event batching. Known to affect JBC 6, in which the challenge event system to incorrectly report that "Can 4 does not intersect circle 4." Supersedes #602.