### PR TITLE
Fix holdover mistakes from rotation

### DIFF
--- a/src/simulator/definitions/robots/demobot.ts
+++ b/src/simulator/definitions/robots/demobot.ts
@@ -34,7 +34,7 @@ export const DEMOBOT: Robot = {
       parentId: 'chassis',
       mass: grams(300),
       origin: {
-        position: Vector3wUnits.meters(-0.06, -0.019, 0),
+        position: Vector3wUnits.meters(0, -0.019, -0.06),
       },
     }),
     left_wheel: Node.motor({
@@ -42,8 +42,8 @@ export const DEMOBOT: Robot = {
       parentAxis: RawVector3.NEGATIVE_Y,
       childAxis: RawVector3.NEGATIVE_Z,
       parentPerpAxis: RawVector3.NEGATIVE_Z,
-      childPerpAxis: RawVector3.NEGATIVE_X,
-      childRotationQuaternion: Quaternion.FromEulerAngles(0, 0, Math.PI / -2),
+      childPerpAxis: RawVector3.X,
+      childRotationQuaternion: Quaternion.FromEulerAngles(0, 0, Math.PI / 2),
       motorPort: 0,
       parentId: 'chassis',
       plug: Node.Motor.Plug.Inverted


### PR DESCRIPTION
Fixes lingering issues caused by #611. Specifically, it was impossible to drive or stop straight.

The Wombat chassis weight node didn't get migrated to new coordinates, so negative X in the new coordinates put it 6 centimeters right of center, rather than back. Also fixed the reversed axes for the wheel which was allowing it to rotate slightly on the wrong axis, exacerbating the issues with driving and stopping straight.