### PR TITLE
Add tabbed interface to the leaderboard

### DIFF
--- a/src/components/interface/NativeScrollContainer.tsx
+++ b/src/components/interface/NativeScrollContainer.tsx
@@ -1,0 +1,11 @@
+import { styled } from 'styletron-react';
+import { nativeScrollbarChrome } from '../../util/nativeScrollbarChrome';
+
+/** Shared native overflow container. Callers remain responsible for sizing it. */
+const NativeScrollContainer = styled('div', {
+  width: '100%',
+  overflow: 'auto',
+  ...nativeScrollbarChrome,
+});
+
+export default NativeScrollContainer;

--- a/src/pages/ClassroomTeacherView.tsx
+++ b/src/pages/ClassroomTeacherView.tsx
@@ -15,7 +15,7 @@ import { withNavigate, WithNavigateProps } from '../util/withNavigate';
 import { AsyncClassroom, Classroom, ClassroomAssignment } from '../state/State/Classroom';
 import { CreateClassroomDialog } from '../components/Dialog/CreateClassroomDialog';
 import Dict from '../util/objectOps/Dict';
-import { nativeScrollbarChrome } from '../util/nativeScrollbarChrome';
+import NativeScrollContainer from '../components/interface/NativeScrollContainer';
 import { ClassroomsAction, listChallengesByStudentId, deleteClassroom } from 'state/reducer/classrooms';
 import { auth } from '../firebase/firebase';
 import { User } from 'ivygate/dist/src/types/user';
@@ -178,12 +178,9 @@ const ClassroomsCardContainer = styled('div', (props: ThemeProps) => ({
   margin: '20px 20px 0px 20px',
 }));
 
-const ClassroomCardScrollContainer = styled('div', (props: { collapsed: boolean }) => ({
-  width: '100%',
-  overflow: 'auto',
-  height: props.collapsed ? '3%' : '33%',
-  ...nativeScrollbarChrome,
-}));
+const ClassroomCardsScroller = styled(NativeScrollContainer, {
+  height: '33%',
+});
 
 const CardWrapper = styled('div', (props: ThemeProps & { selected?: boolean }) => ({
   borderRadius: `${props.theme.itemPadding * 4}px`,
@@ -920,7 +917,7 @@ class ClassroomTeacherView extends React.Component<Props, State> {
               <ClassroomsContainer style={style} theme={theme}>
 
                 {this.state.cardContainerVisible
-                  ? (<ClassroomCardScrollContainer collapsed={!this.state.cardContainerVisible}>
+                  ? (<ClassroomCardsScroller>
 
                     <TourTarget registry={this.registry} targetKey="teacher-classroom-cards-strip" style={{ display: 'contents' }}>
                       <ClassroomsCardContainer style={style} theme={theme}>
@@ -947,7 +944,7 @@ class ClassroomTeacherView extends React.Component<Props, State> {
                     <StickyButtonWrap>
                       <Icon icon={this.state.cardContainerVisible ? faAngleUp : faAngleDown} onClick={() => this.setState({ cardContainerVisible: !this.state.cardContainerVisible })} />
                     </StickyButtonWrap>
-                  </ClassroomCardScrollContainer>) : (
+                  </ClassroomCardsScroller>) : (
                     <div style={{ height: '3%', display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
                       <div>{LocalizedString.lookup(tr('See Classroom Cards'), locale)}</div>
                       <Icon icon={faAngleDown} onClick={() => this.setState({ cardContainerVisible: true })} style={{ marginLeft: '10px' }} />

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -10,10 +10,18 @@ import tr from '@i18n';
 import { jsPDF } from "jspdf";
 import db from '../db';
 import { createRef } from 'react';
-import { LeaderboardEntry } from 'state/State/LimitedChallengeLeaderboard';
+import { TabBar } from '../components/Layout/TabBar';
+import NativeScrollContainer from '../components/interface/NativeScrollContainer';
+import {
+  LEADERBOARD_CATEGORIES,
+  LeaderboardCategoryId,
+  categoryForChallengeId,
+  challengeIdsForCategory,
+  rankUsersForCategory,
+  scoresForCategory,
+} from '../util/leaderboardCategories';
 
 let SELFIDENTIFIER: string;
-let currentUser: User;
 
 interface Challenge {
   name: LocalizedString;
@@ -23,6 +31,7 @@ interface Challenge {
 }
 
 interface Score {
+  challengeId: string;
   name: LocalizedString; // Challenge name
   completed: boolean;
   score?: number;
@@ -46,15 +55,9 @@ interface LeaderboardPrivateProps {
 }
 
 interface LeaderboardState {
-  topEntries: User[];
-  userContext?: User;
-  sortedUsers?: User[];
-  topTen?: User[];
-  currentUserEntry?: LeaderboardEntry;
   loading: boolean;
   error?: string;
-  totalParticipants: number;
-  selected: string;
+  selectedCategory: LeaderboardCategoryId;
   users: Record<string, User>;
   challenges: Record<string, Challenge>;
   showFullLeaderboard: boolean;
@@ -164,30 +167,21 @@ const Table = styled('table', () => ({
   overflow: 'visible'
 
 }));
-const LeaderboardScrollContainer = styled('div', {
-  width: '100%',
-  overflow: 'auto',
-  WebkitOverflowScrolling: 'touch',
-  height: '85%',
-
-  scrollbarWidth: 'thin',
-  scrollbarColor: 'rgba(121,121,121,0.6) transparent',
-
-  '::-webkit-scrollbar': {
-    width: '14px',
-    height: '14px',
-  },
-  '::-webkit-scrollbar-track': {
-    background: 'transparent',
-  },
-  '::-webkit-scrollbar-thumb': {
-    backgroundColor: 'rgba(121,121,121,0.4)',
-    borderRadius: '8px',
-  },
-  '::-webkit-scrollbar-thumb:hover': {
-    backgroundColor: 'rgba(121,121,121,0.7)',
-  },
+const LeaderboardScrollContainer = styled(NativeScrollContainer, {
+  flex: 1,
+  minHeight: 0,
 });
+
+const CategoryTabsScrollContainer = styled(NativeScrollContainer, {
+  flexShrink: 0,
+  overflowY: 'hidden',
+});
+
+const CategoryTabBar = styled(TabBar, (props: ThemeProps) => ({
+  minWidth: '640px',
+  height: '48px',
+  borderBottom: `1px solid ${props.theme.borderColor}`,
+}));
 
 const TableHeader = styled('th', (props: ThemeProps) => ({
   padding: '12px 16px',
@@ -253,6 +247,15 @@ const ErrorState = styled('div', (props: ThemeProps) => ({
   justifyContent: 'center',
   padding: '48px',
   color: '#f44336',
+}));
+
+const EmptyState = styled('div', (props: ThemeProps) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '48px',
+  color: props.theme.color,
+  opacity: 0.7,
 }));
 
 const ButtonContainer = styled('div', {
@@ -354,11 +357,8 @@ class Leaderboard extends React.Component<Props, State> {
     super(props);
 
     this.state = {
-      topEntries: [],
-      userContext: undefined,
-      totalParticipants: 0,
       loading: true,
-      selected: '',
+      selectedCategory: 'jbc',
       users: {},
       challenges: {},
       showFullLeaderboard: false
@@ -390,20 +390,14 @@ class Leaderboard extends React.Component<Props, State> {
 
   private onLog = async () => {
     const res = await db.list('challenge_completion');
-    console.log("Raw leaderboard data: ", res);
     const groupData = res.groupData;
     const userData = res.userData;
 
     let users: Record<string, User> = {};
     const challenges: Record<string, Challenge> = {};
-    // Regex to match `custom-<UUID>`
-    
-    const customChallengeRegex = /^custom-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     for (const [_, attemptedChallenges] of Object.entries(groupData)) {
       for (const [challengeId, challenge] of Object.entries(attemptedChallenges as ChallengeData[])) {
-        console.log(challengeId);
-        // TEMP: Ignore custom challenges
-        if (customChallengeRegex.test(challengeId)) {
+        if (!categoryForChallengeId(challengeId)) {
           continue;
         }
         const challenge = {
@@ -442,12 +436,12 @@ class Leaderboard extends React.Component<Props, State> {
       };
 
       for (const [challengeId, challenge] of Object.entries(userChallenges as ChallengeData[])) {
-        // TEMP: Ignore custom challenges
-        if (customChallengeRegex.test(challengeId)) {
+        if (!categoryForChallengeId(challengeId)) {
           continue;
         }
 
         const score: Score = {
+          challengeId,
           name: tr(challengeId),
           completed: challengeCompletion(challenge)
         };
@@ -479,12 +473,12 @@ class Leaderboard extends React.Component<Props, State> {
       };
 
       for (const [challengeId, challenge] of Object.entries(userChallenges as ChallengeData[])) {
-        // TEMP: Ignore custom challenges
-        if (customChallengeRegex.test(challengeId)) {
+        if (!categoryForChallengeId(challengeId)) {
           continue;
         }
 
         const score: Score = {
+          challengeId,
           name: tr(challengeId),
           completed: challengeCompletion(challenge)
         };
@@ -496,11 +490,7 @@ class Leaderboard extends React.Component<Props, State> {
       }
     }
 
-    const sortedUsers = this.orderUsersByCompletedChallenges(users);
-    const topTen = sortedUsers.slice(0, 10);
-    currentUser = this.getCurrentUser();
-    const me = sortedUsers.find(user => user.id === currentUser.id);
-    const usersById: Record<string, User> = sortedUsers.reduce(
+    const usersById: Record<string, User> = Object.values(users).reduce(
       (acc, user) => {
         acc[user.id] = user;
         return acc;
@@ -510,28 +500,12 @@ class Leaderboard extends React.Component<Props, State> {
     this.setState({
       users: usersById,
       challenges,
-      topTen,
-      userContext: me ? me : undefined,
-      sortedUsers,
       loading: false,
-      totalParticipants: sortedUsers.length
     });
 
     return { users, challenges };
   };
 
-
-  private orderUsersByCompletedChallenges = (users: Record<string, User>): User[] => {
-    const userArray = Object.values(users);
-
-    userArray.sort((a, b) => {
-      const completedChallengesA = a.scores.filter(score => score.completed).length * 100 + a.scores.length;
-      const completedChallengesB = b.scores.filter(score => score.completed).length * 100 + b.scores.length;
-
-      return completedChallengesB - completedChallengesA;
-    });
-    return userArray;
-  };
 
   private anonomizeUsers = (users: Record<string, User>): Record<string, User> => {
     const anonomizedUsers: Record<string, User> = {};
@@ -569,7 +543,8 @@ class Leaderboard extends React.Component<Props, State> {
       anonomizedUsers[user.id] = {
         id: user.id,
         name: `${color}-${element}-${animal}-${number}`,
-        scores: user.scores
+        scores: user.scores,
+        altId: user.altId,
       };
     });
 
@@ -593,49 +568,19 @@ class Leaderboard extends React.Component<Props, State> {
     return anonomizedUsers;
   };
 
-  private customSort = (list: string[]): string[] => {
-    const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
-
-    const isJbc = (s: string) => /^jbc\d+/i.test(s); // case-insensitive test
-
-    return list.sort((a, b) => {
-      const aIsJbc = isJbc(a);
-      const bIsJbc = isJbc(b);
-
-      // 1. Prioritize jbc-prefixed items
-      if (aIsJbc && !bIsJbc) return -1;
-      if (!aIsJbc && bIsJbc) return 1;
-
-      // 2. If both are jbc-prefixed, sort numerically by suffix
-      if (aIsJbc && bIsJbc) {
-        const numA = parseInt(a.replace(/^jbc/i, ""), 10);
-        const numB = parseInt(b.replace(/^jbc/i, ""), 10);
-        return numA - numB;
-      }
-
-      // 3. Otherwise natural alphabetical sort
-      return collator.compare(a, b);
-    });
-  };
-
-  private getCurrentUser = (): User => {
+  private getCurrentUser = (): User | null => {
     const { users } = this.state;
-    let currentUser: User;
     const tokenManager = db.tokenManager;
-    if (tokenManager) {
-      const auth_ = tokenManager.auth();
-      const currentUserAuth_ = auth_.currentUser;
-      currentUser = {
-        id: currentUserAuth_.uid,
-        name: currentUserAuth_.displayName || 'Unknown',
-        scores: Object.values(users).find(u => u.id === currentUserAuth_.uid)?.scores || [],
-        altId: Object.values(users).find(u => u.id === currentUserAuth_.uid)?.altId || 'Unknown'
-      };
+    const currentUserAuth = tokenManager?.auth().currentUser;
+    if (!currentUserAuth) return null;
 
-    }
-
-
-    return currentUser || null;
+    const leaderboardUser = users[currentUserAuth.uid];
+    return {
+      id: currentUserAuth.uid,
+      name: currentUserAuth.displayName || 'Unknown',
+      scores: leaderboardUser?.scores || [],
+      altId: leaderboardUser?.altId || leaderboardUser?.name || 'Unknown'
+    };
   };
 
   private getCurrentUserEmail = (): string | null => {
@@ -652,7 +597,7 @@ class Leaderboard extends React.Component<Props, State> {
     return null;
   };
 
-  // Export current user's JBC scores to PDF - very simple, completed or not completed with timestamp
+  // Export the current user's scores for the selected challenge category.
 
   private exportUserScores = (user: User) => {
     const { locale } = this.props;
@@ -668,7 +613,7 @@ class Leaderboard extends React.Component<Props, State> {
     pdfDoc.text(`Alias: ${user.altId || 'Unknown'}`, 20, 50);
     pdfDoc.text(`Email: ${this.getCurrentUserEmail() || 'Unknown'}`, 20, 60);
 
-    const sortedScores = this.customSort(user.scores.map(s => s.name['en-US'])).map(name => user.scores.find(s => s.name['en-US'] === name));
+    const sortedScores = scoresForCategory(user.scores, this.state.selectedCategory);
 
     // Scores
     pdfDoc.setFontSize(12);
@@ -688,23 +633,31 @@ class Leaderboard extends React.Component<Props, State> {
   };
 
   private handleToggleView = () => {
-    this.setState(
-      prevState => ({
-        showFullLeaderboard: !prevState.showFullLeaderboard,
-        loading: false, // Show loading immediately
-      }),
-      () => {
-        // Fetch new data
+    this.setState(prevState => ({
+      showFullLeaderboard: !prevState.showFullLeaderboard,
+    }));
+  };
 
-      }
-    );
+  private handleCategoryChange = (index: number) => {
+    const category = LEADERBOARD_CATEGORIES[index];
+    if (!category || category.id === this.state.selectedCategory) return;
+
+    this.setState({ selectedCategory: category.id }, () => {
+      this.leaderboardScrollRef.current?.scrollTo({ top: 0, left: 0 });
+    });
   };
 
   private renderLeaderboard = () => {
 
     const { locale, theme } = this.props;
-    const { topEntries, userContext, loading, error, users, challenges, topTen, sortedUsers } = this.state;
-    const challengeArray = this.customSort(Object.keys(challenges));
+    const { loading, error, users, challenges, selectedCategory, showFullLeaderboard } = this.state;
+    const challengeArray = challengeIdsForCategory(Object.keys(challenges), selectedCategory);
+    const sortedUsers = rankUsersForCategory(users, selectedCategory);
+    const topTen = sortedUsers.slice(0, 10);
+    const currentUser = this.getCurrentUser();
+    const userContext = currentUser
+      ? sortedUsers.find(user => user.id === currentUser.id)
+      : undefined;
 
     if (loading) {
       return (
@@ -723,10 +676,17 @@ class Leaderboard extends React.Component<Props, State> {
       );
     }
 
-    // Check if user is in top entries (to avoid duplicate display)
-    const userInTopEntries = userContext && topEntries.some(e => e.id === userContext.id);
-    // Show user context section only if user has a completion and is not in top N
-    const showUserContextSection = userContext && !userInTopEntries;
+    if (sortedUsers.length === 0) {
+      return (
+        <EmptyState theme={theme}>
+          {LocalizedString.lookup(tr('No completions in this challenge category yet.'), locale)}
+        </EmptyState>
+      );
+    }
+
+    const userInTopTen = userContext && topTen.some(entry => entry.id === userContext.id);
+    const showUserContextSection = !showFullLeaderboard && userContext && !userInTopTen;
+    const tableUsers = showFullLeaderboard ? sortedUsers : topTen;
     return (
       <LeaderboardScrollContainer ref={this.leaderboardScrollRef}>
         <Table>
@@ -745,37 +705,29 @@ class Leaderboard extends React.Component<Props, State> {
 
             </tr>
           </thead>
-          {this.state.showFullLeaderboard
-            ? <tbody>
-              {sortedUsers.map((entry, index) => {
-                const rank = index + 1;
-                const isCurrentUser = currentUser.id === entry.id;
-                return this.renderLeaderboardRow(entry, rank, isCurrentUser, challengeArray);
-              })}
-            </tbody>
-            : <tbody>
-              {/* Top ten entries */}
-              {topTen.map((entry, index) => {
-                const rank = index + 1;
-                const isCurrentUser = currentUser.id === entry.id;
-                return this.renderLeaderboardRow(entry, rank, isCurrentUser, challengeArray);
-              })}
+          <tbody>
+            {tableUsers.map((entry, index) => {
+              const rank = index + 1;
+              const isCurrentUser = currentUser?.id === entry.id;
+              return this.renderLeaderboardRow(entry, rank, isCurrentUser, challengeArray);
+            })}
 
-              {/* Separator and user context section */}
-              {showUserContextSection && (
-                <>
-                  <SectionSeparator theme={theme}>
-                    <SeparatorCell theme={theme} colSpan={4}>
-                      ··· {LocalizedString.lookup(tr('Your position'), locale)} ···
-                    </SeparatorCell>
-                  </SectionSeparator>
-                  {/* User's entry */}
-                  {this.renderLeaderboardRow(userContext, sortedUsers.findIndex(user => user.id === currentUser.id) + 1, true, challengeArray)}
-
-                </>
-              )}
-            </tbody>
-          }
+            {showUserContextSection && (
+              <>
+                <SectionSeparator theme={theme}>
+                  <SeparatorCell theme={theme} colSpan={challengeArray.length + 2}>
+                    ··· {LocalizedString.lookup(tr('Your position'), locale)} ···
+                  </SeparatorCell>
+                </SectionSeparator>
+                {this.renderLeaderboardRow(
+                  userContext,
+                  sortedUsers.findIndex(user => user.id === userContext.id) + 1,
+                  true,
+                  challengeArray
+                )}
+              </>
+            )}
+          </tbody>
         </Table>
       </LeaderboardScrollContainer>
 
@@ -790,9 +742,8 @@ class Leaderboard extends React.Component<Props, State> {
   };
   private renderLeaderboardRow = (entry: User, rank: number, isCurrentUser: boolean, challengeArray: string[]) => {
     const { theme, locale } = this.props;
-    const { challenges } = this.state;
     return (
-      <TableRow key={`${entry.id}-${rank}`} theme={theme} $highlight={isCurrentUser} ref={entry.name === SELFIDENTIFIER ? this.myScoresRef : null}>
+      <TableRow key={`${entry.id}-${rank}`} theme={theme} $highlight={isCurrentUser} ref={isCurrentUser ? this.myScoresRef : null}>
 
         <StickyRankTd theme={theme} rank={rank} $highlight={isCurrentUser} >#{rank}</StickyRankTd>
         <StickyNameTd theme={theme} $highlight={isCurrentUser}>
@@ -800,7 +751,7 @@ class Leaderboard extends React.Component<Props, State> {
           {isCurrentUser && ` (${LocalizedString.lookup(tr('You'), locale)})`}
         </StickyNameTd>
         {challengeArray.map((id) => {
-          const userScore = entry.scores.find(score => score.name['en-US'] === challenges[id].name['en-US']);
+          const userScore = entry.scores.find(score => score.challengeId === id);
           return (
             <TableCell key={id} theme={theme}>
               {!userScore && '-'}
@@ -822,15 +773,25 @@ class Leaderboard extends React.Component<Props, State> {
   private renderClassroomLeaderboardNew = () => {
     const { theme, locale } = this.props;
     const currentUser = this.getCurrentUser();
+    const selectedCategoryIndex = LEADERBOARD_CATEGORIES.findIndex(
+      category => category.id === this.state.selectedCategory
+    );
+    const totalParticipants = rankUsersForCategory(
+      this.state.users,
+      this.state.selectedCategory
+    ).length;
+    const categoryTabs: TabBar.TabDescription[] = LEADERBOARD_CATEGORIES.map(category => ({
+      name: LocalizedString.lookup(category.label, locale),
+    }));
     return (
       <ContentContainer theme={theme}>
         <LeaderboardContainer theme={theme}>
           <LeaderboardHeader theme={theme}>
             <LeaderboardTitle theme={theme}>
               {LocalizedString.lookup(tr('Leaderboard'), locale)}
-              {this.state.totalParticipants > 0 && (
+              {totalParticipants > 0 && (
                 <span style={{ fontSize: '0.7em', fontWeight: 'normal', opacity: 0.7, marginLeft: '8px' }}>
-                  ({this.state.totalParticipants} {LocalizedString.lookup(tr('participants'), locale)})
+                  ({totalParticipants} {LocalizedString.lookup(tr('participants'), locale)})
                 </span>
               )}
             </LeaderboardTitle>
@@ -846,6 +807,14 @@ class Leaderboard extends React.Component<Props, State> {
               </LeaderboardViewToggleButton>
             </LeaderboardViewToggle>
           </LeaderboardHeader>
+          <CategoryTabsScrollContainer>
+            <CategoryTabBar
+              tabs={categoryTabs}
+              index={selectedCategoryIndex}
+              onIndexChange={this.handleCategoryChange}
+              theme={theme}
+            />
+          </CategoryTabsScrollContainer>
           {currentUser && (
             <YourNameContainer theme={theme}>
               <YourNameLabel theme={theme}>
@@ -864,7 +833,7 @@ class Leaderboard extends React.Component<Props, State> {
   render() {
     const { props, } = this;
     const { style, theme } = props;
-    currentUser = this.getCurrentUser();
+    const currentUser = this.getCurrentUser();
 
     return (
       <PageContainer style={style} theme={theme}>
@@ -874,7 +843,7 @@ class Leaderboard extends React.Component<Props, State> {
             <h1>{LocalizedString.lookup(tr('KIPR All Time Leaderboard'), props.locale)}</h1>
 
             <ButtonContainer>
-              <Button theme={DARK} onClick={() => this.exportUserScores(currentUser)}> {LocalizedString.lookup(tr('Export My Scores!'), props.locale)}</Button>
+              <Button theme={DARK} onClick={() => currentUser && this.exportUserScores(currentUser)}> {LocalizedString.lookup(tr('Export My Scores!'), props.locale)}</Button>
               <Button theme={DARK} onClick={this.scrollToMyScores}> {LocalizedString.lookup(tr('Scroll to My Scores!'), props.locale)}</Button>
             </ButtonContainer>
 

--- a/src/util/leaderboardCategories.ts
+++ b/src/util/leaderboardCategories.ts
@@ -1,0 +1,129 @@
+import tr from '@i18n';
+import LocalizedString from './LocalizedString';
+
+export type LeaderboardCategoryId = 'jbc' | 'bex26' | 'gcer25';
+
+export interface LeaderboardCategory {
+  id: LeaderboardCategoryId;
+  label: LocalizedString;
+  challengeIds: readonly string[];
+}
+
+const JBC_CHALLENGE_IDS = [
+  'jbc0', 'jbc1', 'jbc2', 'jbc3', 'jbc4', 'jbc5', 'jbc6', 'jbc7', 'jbc8', 'jbc9',
+  'jbc10', 'jbc11', 'jbc12', 'jbc14', 'jbc15', 'jbc16', 'jbc17', 'jbc18', 'jbc19',
+  'jbc20', 'jbc21', 'jbc22', 'jbc23', 'jbc24',
+] as const;
+
+const BEX26_CHALLENGE_IDS = [
+  'bex1', 'bex2', 'bex3', 'bex4', 'bex5', 'bex6', 'bex7', 'bex8', 'bex9',
+  'bex10', 'bex11', 'bex12', 'bex13', 'bex14', 'bex15', 'bex16', 'bex17', 'bex18',
+] as const;
+
+const GCER25_CHALLENGE_IDS = [
+  'Bulldozer_Mania',
+  'Cover_Your_Bases',
+  'Entree_Express',
+  'Find_The_Black_Line',
+  'Ice_Ice_Botguy',
+  'Mountain_Rescue',
+  'Odd_Numbers',
+  'Sense_The_Can',
+  'Special_Sauce',
+  'Thirst_Quencher',
+] as const;
+
+export const LEADERBOARD_CATEGORIES: readonly LeaderboardCategory[] = [
+  {
+    id: 'jbc',
+    label: tr('Junior Botball Challenge (JBC)'),
+    challengeIds: JBC_CHALLENGE_IDS,
+  },
+  {
+    id: 'bex26',
+    label: tr('Botball Explorer 2026'),
+    challengeIds: BEX26_CHALLENGE_IDS,
+  },
+  {
+    id: 'gcer25',
+    label: tr('GCER 2025'),
+    challengeIds: GCER25_CHALLENGE_IDS,
+  },
+];
+
+const CATEGORY_BY_CHALLENGE_ID = LEADERBOARD_CATEGORIES.reduce(
+  (categories, category) => {
+    for (const challengeId of category.challengeIds) categories.set(challengeId, category.id);
+    return categories;
+  },
+  new Map<string, LeaderboardCategoryId>()
+);
+
+const CHALLENGE_ORDER_BY_CATEGORY = LEADERBOARD_CATEGORIES.reduce(
+  (orders, category) => {
+    orders.set(
+      category.id,
+      new Map(category.challengeIds.map((challengeId, index) => [challengeId, index]))
+    );
+    return orders;
+  },
+  new Map<LeaderboardCategoryId, Map<string, number>>()
+);
+
+export interface LeaderboardCategoryScore {
+  challengeId: string;
+  completed: boolean;
+}
+
+export interface LeaderboardCategoryUser {
+  scores: readonly LeaderboardCategoryScore[];
+}
+
+export function categoryForChallengeId(challengeId: string): LeaderboardCategoryId | undefined {
+  return CATEGORY_BY_CHALLENGE_ID.get(challengeId);
+}
+
+export function challengeBelongsToCategory(
+  challengeId: string,
+  categoryId: LeaderboardCategoryId
+): boolean {
+  return categoryForChallengeId(challengeId) === categoryId;
+}
+
+export function challengeIdsForCategory(
+  challengeIds: readonly string[],
+  categoryId: LeaderboardCategoryId
+): string[] {
+  const order = CHALLENGE_ORDER_BY_CATEGORY.get(categoryId);
+  return challengeIds
+    .filter(challengeId => challengeBelongsToCategory(challengeId, categoryId))
+    .sort((a, b) => (order?.get(a) ?? Number.MAX_SAFE_INTEGER) - (order?.get(b) ?? Number.MAX_SAFE_INTEGER));
+}
+
+export function scoresForCategory<T extends LeaderboardCategoryScore>(
+  scores: readonly T[],
+  categoryId: LeaderboardCategoryId
+): T[] {
+  const scoreIds = challengeIdsForCategory(scores.map(score => score.challengeId), categoryId);
+  const scoresById = new Map(scores.map(score => [score.challengeId, score]));
+  return scoreIds.map(challengeId => scoresById.get(challengeId)).filter((score): score is T => Boolean(score));
+}
+
+export function rankUsersForCategory<T extends LeaderboardCategoryUser>(
+  users: Record<string, T>,
+  categoryId: LeaderboardCategoryId
+): T[] {
+  const rankScore = (user: LeaderboardCategoryUser): number => {
+    return user.scores.reduce(
+      (total, score) => {
+        if (!challengeBelongsToCategory(score.challengeId, categoryId)) return total;
+        return total + (score.completed ? 101 : 1);
+      },
+      0
+    );
+  };
+
+  return Object.values(users)
+    .filter(user => user.scores.some(score => challengeBelongsToCategory(score.challengeId, categoryId)))
+    .sort((a, b) => rankScore(b) - rankScore(a));
+}

--- a/test/util/leaderboardCategories.test.ts
+++ b/test/util/leaderboardCategories.test.ts
@@ -1,0 +1,114 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  LEADERBOARD_CATEGORIES,
+  categoryForChallengeId,
+  challengeIdsForCategory,
+  rankUsersForCategory,
+  scoresForCategory,
+} from '../../src/util/leaderboardCategories';
+
+describe('leaderboard challenge categories', () => {
+  test('exposes the requested categories in display order', () => {
+    expect(LEADERBOARD_CATEGORIES.map(category => [category.id, category.label['en-US']])).toEqual([
+      ['jbc', 'Junior Botball Challenge (JBC)'],
+      ['bex26', 'Botball Explorer 2026'],
+      ['gcer25', 'GCER 2025'],
+    ]);
+  });
+
+  test('stays synchronized with the challenge definition directories', () => {
+    const definitionsRoot = path.resolve(__dirname, '../../src/simulator/definitions/challenges');
+    const categoryIds = new Map(
+      LEADERBOARD_CATEGORIES.map(category => [category.id, [...category.challengeIds]])
+    );
+    const numericIdSort = (a: string, b: string) => {
+      return Number(a.match(/\d+/)?.[0]) - Number(b.match(/\d+/)?.[0]);
+    };
+
+    const jbcIds = fs.readdirSync(definitionsRoot, { withFileTypes: true })
+      .filter(entry => entry.isFile() && /^jbc\d+-.*\.ts$/.test(entry.name))
+      .map(entry => entry.name.match(/^(jbc\d+)-/)?.[1])
+      .filter((challengeId): challengeId is string => Boolean(challengeId))
+      .sort(numericIdSort);
+    const bexIds = fs.readdirSync(path.join(definitionsRoot, 'bex26'))
+      .map(fileName => fileName.match(/^(bex\d+)-/)?.[1])
+      .filter((challengeId): challengeId is string => Boolean(challengeId))
+      .sort(numericIdSort);
+    const gcerIds = fs.readdirSync(path.join(definitionsRoot, 'gcer25'))
+      .sort()
+      .map(fileName => fs.readFileSync(path.join(definitionsRoot, 'gcer25', fileName), 'utf8'))
+      .map(source => source.match(/sceneId:\s*['"]([^'"]+)['"]/)?.[1])
+      .filter((challengeId): challengeId is string => Boolean(challengeId));
+
+    expect(categoryIds.get('jbc')).toEqual(jbcIds);
+    expect(categoryIds.get('bex26')).toEqual(bexIds);
+    expect(categoryIds.get('gcer25')).toEqual(gcerIds);
+  });
+
+  test('classifies current scene ids and excludes archived, custom, and unknown ids', () => {
+    expect(categoryForChallengeId('jbc0')).toBe('jbc');
+    expect(categoryForChallengeId('jbc24')).toBe('jbc');
+    expect(categoryForChallengeId('bex18')).toBe('bex26');
+    expect(categoryForChallengeId('Find_The_Black_Line')).toBe('gcer25');
+    expect(categoryForChallengeId('jbc13')).toBeUndefined();
+    expect(categoryForChallengeId('jbc2b')).toBeUndefined();
+    expect(categoryForChallengeId('custom-123')).toBeUndefined();
+    expect(categoryForChallengeId('future-challenge')).toBeUndefined();
+  });
+
+  test('filters and orders category challenges according to their definition order', () => {
+    expect(challengeIdsForCategory(['bex10', 'jbc2', 'bex2', 'unknown'], 'bex26')).toEqual([
+      'bex2',
+      'bex10',
+    ]);
+    expect(challengeIdsForCategory([
+      'Thirst_Quencher',
+      'Bulldozer_Mania',
+      'jbc0',
+    ], 'gcer25')).toEqual(['Bulldozer_Mania', 'Thirst_Quencher']);
+  });
+
+  test('ranks only participants in the selected category', () => {
+    const users = {
+      one: {
+        id: 'one',
+        scores: [
+          { challengeId: 'jbc0', completed: true },
+          { challengeId: 'jbc1', completed: false },
+          { challengeId: 'bex1', completed: true },
+        ],
+      },
+      two: {
+        id: 'two',
+        scores: [
+          { challengeId: 'jbc0', completed: true },
+          { challengeId: 'jbc1', completed: true },
+        ],
+      },
+      three: {
+        id: 'three',
+        scores: [{ challengeId: 'bex2', completed: false }],
+      },
+      unknown: {
+        id: 'unknown',
+        scores: [{ challengeId: 'custom-123', completed: true }],
+      },
+    };
+
+    expect(rankUsersForCategory(users, 'jbc').map(user => user.id)).toEqual(['two', 'one']);
+    expect(rankUsersForCategory(users, 'bex26').map(user => user.id)).toEqual(['one', 'three']);
+    expect(rankUsersForCategory(users, 'gcer25')).toEqual([]);
+  });
+
+  test('selects active-category export scores in challenge order', () => {
+    const scores = [
+      { challengeId: 'bex10', completed: false, label: 'ten' },
+      { challengeId: 'jbc0', completed: true, label: 'jbc' },
+      { challengeId: 'bex2', completed: true, label: 'two' },
+    ];
+
+    expect(scoresForCategory(scores, 'bex26').map(score => score.label)).toEqual(['two', 'ten']);
+    expect(scoresForCategory(scores, 'gcer25')).toEqual([]);
+  });
+});


### PR DESCRIPTION
This PR extracts the tab bar component from the existing classroom interface and uses it to organize the challenges on the leaderboard into three categories:

- JBC
- BEX
- GCER 2025

Each leaderboard sorts based only on the challenges that it displays. Users that have not attempted any challenges in that category are not displayed. Due to database interface restrictions, it always has to pull all challenge completions, regardless of which tab is currently active.