### PR TITLE
Keep edited robot start location across challenge Reset World

### DIFF
--- a/src/pages/ChallengeRoot.tsx
+++ b/src/pages/ChallengeRoot.tsx
@@ -292,6 +292,10 @@ class Root extends React.Component<Props, State> {
       );
     }
 
+    if (this.workingChallengeScene_) {
+      sceneToLoad = Scene.copyRobotStartingOrigins(this.workingChallengeScene_, sceneToLoad);
+    }
+
     const latestChallengeCompletion =
       Async.latestValue(store.getState().challengeCompletions[challengeId]) ??
       Async.latestValue(this.props.challengeCompletion);
@@ -367,14 +371,28 @@ class Root extends React.Component<Props, State> {
     reinstantiateCustomChallengeRuntimeScript(binding.scriptManager, scene);
   };
 
+  private incrementNonce_ = () => {
+    this.setState({
+      nonce: (this.state.nonce + 1) % 100000
+    });
+  };
+
   private onNodeChange_ = (nodeId: string, node: Node) => {
     if (!this.workingChallengeScene_) return;
     this.workingChallengeScene_ = Scene.setNode(this.workingChallengeScene_, nodeId, node);
-    const binding = Space.getInstance().sceneBinding;
-    if (binding) {
-      binding.applyNodeFromScript(nodeId, node);
-      binding.scriptManager.scene = Scene.setNode(binding.scriptManager.scene, nodeId, node);
+    const space = Space.getInstance();
+    const binding = space.sceneBinding;
+    if (!binding) return;
+
+    if (node.type === 'robot') {
+      space.replaceSceneState(this.workingChallengeScene_);
+      binding.syncNodeOriginsFromScene(this.workingChallengeScene_);
+      this.incrementNonce_();
+      return;
     }
+
+    binding.applyNodeFromScript(nodeId, node);
+    binding.scriptManager.scene = Scene.setNode(binding.scriptManager.scene, nodeId, node);
   };
 
   private onNodeAdd_ = this.onNodeChange_;
@@ -737,6 +755,7 @@ class Root extends React.Component<Props, State> {
     if (this.props.params.challengeId !== prevProps.params.challengeId) {
       this.appliedCompletionSceneDiff_ = false;
       this.lastSyncedPropsScene_ = undefined;
+      this.workingChallengeScene_ = undefined;
     }
 
     const latestScene = Async.latestValue(this.props.scene);

--- a/src/pages/LimitedChallengeRoot.tsx
+++ b/src/pages/LimitedChallengeRoot.tsx
@@ -296,7 +296,11 @@ class LimitedChallengeRoot extends React.Component<Props, State> {
     if (!challengeCompletion) return;
 
     this.onStopClick_();
-    this.workingChallengeScene = Async.latestValue(scene);
+    const previousWorking = this.workingChallengeScene_;
+    const latestScene = Async.latestValue(scene);
+    this.workingChallengeScene = previousWorking && latestScene
+      ? Scene.copyRobotStartingOrigins(previousWorking, latestScene)
+      : latestScene;
 
     const latestChallenge = Async.latestValue(challenge);
     const latestChallengeCompletion = Async.latestValue(challengeCompletion);

--- a/src/state/State/Scene/index.ts
+++ b/src/state/State/Scene/index.ts
@@ -242,6 +242,38 @@ namespace Scene {
     return { ...scene, nodes };
   };
 
+  /**
+   * Copy robot `startingOrigin` from `source` onto `target`, and set those robots'
+   * `origin` to match. Used so challenge Reset World keeps an edited start pose,
+   * like regular-scene soft reset.
+   */
+  export const copyRobotStartingOrigins = (source: Scene, target: Scene): Scene => {
+    const sourceRobots = robots(source);
+    let nodes = target.nodes;
+    let changed = false;
+    for (const robotId of Object.keys(sourceRobots)) {
+      const src = sourceRobots[robotId];
+      const dst = nodes[robotId];
+      if (!dst || dst.type !== 'robot') continue;
+      const startingOrigin = src.startingOrigin;
+      if (!startingOrigin) continue;
+      changed = true;
+      nodes = {
+        ...nodes,
+        [robotId]: {
+          ...dst,
+          startingOrigin,
+          origin: {
+            position: startingOrigin.position,
+            orientation: startingOrigin.orientation,
+            scale: startingOrigin.scale,
+          },
+        },
+      };
+    }
+    return changed ? { ...target, nodes } : target;
+  };
+
   export const addObject = (scene: Scene, nodeId: string, obj: Node.Obj, geometry: Geometry): Scene => ({
     ...scene,
     nodes: {

--- a/test/state/Scene.spec.ts
+++ b/test/state/Scene.spec.ts
@@ -1,0 +1,80 @@
+import Scene from '../../src/state/State/Scene';
+import Node from '../../src/state/State/Scene/Node';
+import LocalizedString from '../../src/util/LocalizedString';
+import { Vector3wUnits } from '../../src/util/math/unitMath';
+
+const originAt = (x: number, z: number) => ({
+  position: Vector3wUnits.centimeters(x, 0, z),
+});
+
+const sceneWith = (nodes: Scene['nodes']): Scene => ({
+  ...Scene.EMPTY,
+  nodes,
+});
+
+describe('Scene.copyRobotStartingOrigins', () => {
+  it('copies robot startingOrigin onto the target and sets origin to match', () => {
+    const source = sceneWith({
+      robot: {
+        ...Node.Robot.NIL,
+        robotId: 'demobot',
+        origin: originAt(50, 10),
+        startingOrigin: originAt(25, 5),
+      },
+      can: {
+        type: 'object',
+        name: { [LocalizedString.EN_US]: 'Can' },
+        geometryId: 'can',
+        origin: originAt(1, 1),
+        startingOrigin: originAt(0, 0),
+      },
+    });
+    const target = sceneWith({
+      robot: {
+        ...Node.Robot.NIL,
+        robotId: 'demobot',
+        origin: originAt(0, 0),
+        startingOrigin: originAt(0, 0),
+      },
+      can: {
+        type: 'object',
+        name: { [LocalizedString.EN_US]: 'Can' },
+        geometryId: 'can',
+        origin: originAt(9, 9),
+        startingOrigin: originAt(0, 0),
+      },
+    });
+
+    const next = Scene.copyRobotStartingOrigins(source, target);
+    const robot = next.nodes.robot;
+    expect(robot.type).toBe('robot');
+    expect(robot.startingOrigin).toEqual(originAt(25, 5));
+    expect(robot.origin).toEqual({
+      position: originAt(25, 5).position,
+      orientation: undefined,
+      scale: undefined,
+    });
+    expect(next.nodes.can.origin).toEqual(originAt(9, 9));
+    expect(next.nodes.can.startingOrigin).toEqual(originAt(0, 0));
+  });
+
+  it('leaves the target unchanged when there is no matching robot start pose', () => {
+    const source = sceneWith({
+      other: {
+        ...Node.Robot.NIL,
+        robotId: 'demobot',
+        startingOrigin: originAt(3, 3),
+      },
+    });
+    const target = sceneWith({
+      robot: {
+        ...Node.Robot.NIL,
+        robotId: 'demobot',
+        origin: originAt(0, 0),
+        startingOrigin: originAt(0, 0),
+      },
+    });
+
+    expect(Scene.copyRobotStartingOrigins(source, target)).toBe(target);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In regular scenes, changing the robot Start Location in the Robot panel writes `startingOrigin`, so Reset World puts the robot back at that edited pose.

Challenges were reloading the definition scene on reset, which discarded the edited start pose.

This change:

- Copies robot `startingOrigin` from the working challenge scene onto the reloaded scene (same idea as regular-scene soft reset)
- Applies Info-panel start-location edits to the live robot in challenges (origin sync + UI refresh)
- Does the same preserve on limited-challenge reset

Object poses still reset to the challenge definition. Only the robot start pose is kept.

## Test plan

- Open a JBC challenge, change X/Y/Z/Rotation under Start Location, confirm the robot moves
- Click Reset World / Reset Challenge and confirm the robot returns to the edited start, not the original definition
- Confirm cans/other objects still reset to their original starts
- Repeat start-location edit + reset more than once
- Limited challenges: same start-location + reset behavior

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-774dc42f-6395-4434-b939-193633ea4365?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-774dc42f-6395-4434-b939-193633ea4365&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

